### PR TITLE
ENH reduce over a whole region

### DIFF
--- a/metadetect/metadetect.py
+++ b/metadetect/metadetect.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import ngmix
 from ngmix.gexceptions import BootPSFFailure
@@ -6,6 +7,8 @@ from . import detect
 from . import fitting
 from . import procflags
 from . import shearpos
+
+logger = logging.getLogger(__name__)
 
 
 def do_metadetect(config, mbobs, rng):
@@ -186,6 +189,7 @@ class Metadetect(dict):
             cclip = _clip_and_round(cols_noshear, dims[1])
 
             if 'ormask_region' in self and self['ormask_region'] > 1:
+                logger.debug('ormask_region: %s' % self['ormask_region'])
                 for ind in range(cat.size):
                     lr = int(min(
                         dims[0]-1,


### PR DESCRIPTION
This PR allows us to set the ormask for each detection as the "or" of the ormask over a region around the center of the stamp. Currently, this is specified by setting the option `ormask_region` to an int in the config. This int is half of the final desired region.