### PR TITLE
TST always run shear tests on master

### DIFF
--- a/.github/workflows/shear_test.yml
+++ b/.github/workflows/shear_test.yml
@@ -33,6 +33,9 @@ jobs:
           conda install --quiet --yes --file dev-requirements.txt
           conda install --quiet --yes joblib tqdm
 
+          conda uninstall ngmix --force -y
+          pip install git+https://github.com/esheldon/ngmix.git        
+
           python -m pip install -e .
 
       - name: test shear meas


### PR DESCRIPTION
This PR changes the shear tests to always use ngmix master.