### PR TITLE
remove DETECTED bit

### DIFF
--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -670,6 +670,7 @@ def get_output(wcs, source, res, bmask, stamp_size, exp_bbox):
     ndarray
         Has the fields from res, with new fields added, see get_output_dtype
     """
+    import lsst.afw.image as afw_image
 
     output = get_output_struct(res)
 
@@ -700,7 +701,10 @@ def get_output(wcs, source, res, bmask, stamp_size, exp_bbox):
     output['ra'] = skypos.getRa().asDegrees()
     output['dec'] = skypos.getDec().asDegrees()
 
-    output['bmask'] = bmask
+    # remove DETECTED bit, it is just clutter since all detected
+    # objects have this bit set
+    detected = afw_image.Mask.getPlaneBitMask('DETECTED')
+    output['bmask'] = bmask & ~detected
 
     return output
 

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -14,6 +14,7 @@ from metadetect.lsst import util
 import descwl_shear_sims
 from descwl_coadd.coadd import make_coadd
 from descwl_coadd.coadd_nowarp import make_coadd_nowarp
+import lsst.afw.image as afw_image
 
 logging.basicConfig(
     stream=sys.stdout,
@@ -99,7 +100,11 @@ def test_lsst_metadetect_smoke(meas_type, subtract_sky):
     if meas_type is not None:
         config['meas_type'] = meas_type
 
+    detected = afw_image.Mask.getPlaneBitMask('DETECTED')
     res = run_metadetect(rng=rng, config=config, **data)
+
+    # we remove the DETECTED bit
+    assert np.all(res['noshear']['bmask'] & detected == 0)
 
     if meas_type is None:
         front = 'wmom'


### PR DESCRIPTION
It is just clutter since all objects have it set.  We want to
see zero in the output bmask except where some problem occured.