### PR TITLE
BUG make sure to correct for all zero weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### fixed
 
+ - Fixed bug where ngmix observations with all zero weights were not flagged 
+   properly.
 
 ## 0.6.0 - 2021-12-10
 

--- a/metadetect/masking.py
+++ b/metadetect/masking.py
@@ -53,6 +53,8 @@ def apply_apodization_corrections(*, mbobs, ap_rad, mask_bit_val):
                     if msk[0].size == obs.image.size:
                         obs.ignore_zero_weight = False
                     obs.weight[msk] = 0.0
+                    if np.all(obs.weight == 0):
+                        obs.ignore_zero_weight = False
 
 
 @njit
@@ -210,6 +212,8 @@ def _apply_mask_interp(
                     if np.all(bad_logic):
                         obs.ignore_zero_weight = False
                     obs.weight[wbad] = 0.0
+                    if np.all(obs.weight == 0):
+                        obs.ignore_zero_weight = False
 
                     if not np.all(bad_logic):
                         wmsk = obs.weight > 0
@@ -282,6 +286,8 @@ def _apply_mask_apodize(
                     if np.all(msk):
                         obs.ignore_zero_weight = False
                     obs.weight[msk] = 0.0
+                    if np.all(obs.weight == 0):
+                        obs.ignore_zero_weight = False
 
 
 def make_foreground_bmask(


### PR DESCRIPTION
This PR makes sure the code doesn't fail for all zero weights.