### PR TITLE
BUG do not coadd by default and new LSST apis

### DIFF
--- a/.github/workflows/lsst-tests-ngmix-upstream.yml
+++ b/.github/workflows/lsst-tests-ngmix-upstream.yml
@@ -11,7 +11,7 @@ jobs:
     name: lsst-tests-ngmix-upstream
     strategy:
       matrix:
-        pyver: [3.8]
+        pyver: ["3.10"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: lsst-tests
     strategy:
       matrix:
-        pyver: [3.8]
+        pyver: ["3.10"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/shear_test.yml
+++ b/.github/workflows/shear_test.yml
@@ -11,7 +11,7 @@ jobs:
     name: shear-tests
     strategy:
       matrix:
-        pyver: [3.8]
+        pyver: ["3.10"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/tests-ngmix-upstream.yml
+++ b/.github/workflows/tests-ngmix-upstream.yml
@@ -11,7 +11,7 @@ jobs:
     name: tests-ngmix-upstream
     strategy:
       matrix:
-        pyver: ["3.8", "3.9", "3.10"]
+        pyver: ["3.9", "3.10"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: tests
     strategy:
       matrix:
-        pyver: ["3.8", "3.9", "3.10"]
+        pyver: ["3.9", "3.10"]
 
     runs-on: "ubuntu-latest"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### fixed
 
+## 0.12.0 - 2023-04-03
+
+### changed
+
+ - Turned off coadding for joint fits by default.
+
 ## 0.11.0 - 2022-12-05
 
 ### changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### changed
 
  - Turned off coadding for joint fits by default.
+ - Changed LSST codes to use new DM APIs for filter labels.
 
 ## 0.11.0 - 2022-12-05
 

--- a/metadetect/fitting.py
+++ b/metadetect/fitting.py
@@ -36,7 +36,7 @@ def fit_mbobs_gauss(
     shear_bands=None,
     obj_runner=None,
     psf_runner=None,
-    coadd=True,
+    coadd=False,
 ):
     """Fit a multiband obs using a Gaussian fit.
 
@@ -58,7 +58,7 @@ def fit_mbobs_gauss(
         If not None, the result of `get_gauss_psf_runner` is suggested. If None,
         `get_gauss_psf_runner` is called.
     coadd : bool, optional
-        If True, coadd the mbobs over all bands and then fit. Default is True.
+        If True, coadd the mbobs over all bands and then fit. Default is False.
 
     Returns
     -------
@@ -273,7 +273,7 @@ def _make_ml_prior(rng, scale, nband):
 
 def fit_mbobs_list_joint(
     *, mbobs_list, fitter_name, bmask_flags, rng, shear_bands=None,
-    symmetrize=True, coadd=True,
+    symmetrize=True, coadd=False,
 ):
     """Fit the ojects in a list of ngmix.MultiBandObsList using a joint fitter.
 
@@ -296,7 +296,7 @@ def fit_mbobs_list_joint(
         If True, apply 4-fold symmetry to the mask+weight map. Default is True.
         Ignored for gaussian fits.
     coadd : bool, optional
-        If True, coadd the mbobs over all bands and then fit. Default is True.
+        If True, coadd the mbobs over all bands and then fit. Default is False.
         Ignored for adaptive moments which always coadds.
 
     Returns

--- a/metadetect/lsst/util.py
+++ b/metadetect/lsst/util.py
@@ -301,11 +301,11 @@ def get_mbexp(exposures):
     """
     from lsst.afw.image import MultibandExposure
 
-    filters = [exp.getFilterLabel().bandLabel for exp in exposures]
+    filters = [exp.getFilter().bandLabel for exp in exposures]
     mbexp = MultibandExposure.fromExposures(filters, exposures)
 
     for exp, sexp in zip(exposures, mbexp.singles):
-        sexp.setFilterLabel(exp.getFilterLabel())
+        sexp.setFilter(exp.getFilter())
         sexp.setWcs(exp.getWcs())
 
     return mbexp
@@ -337,7 +337,7 @@ def copy_mbexp(mbexp, clear=False):
         new_mbexp[band].setPsf(psf)
 
     for new_exp, exp in zip(new_mbexp.singles, mbexp.singles):
-        new_exp.setFilterLabel(exp.getFilterLabel())
+        new_exp.setFilter(exp.getFilter())
         new_exp.setWcs(exp.getWcs())
 
     if clear:

--- a/metadetect/metadetect.py
+++ b/metadetect/metadetect.py
@@ -276,7 +276,7 @@ class Metadetect(dict):
                 if "fwhm" not in cfg["weight"]:
                     cfg["weight"]["fwhm"] = 1.2
 
-                coadd = cfg.get("coadd", True)
+                coadd = cfg.get("coadd", False)
             else:
                 raise ValueError("bad model: '%s'" % model)
 


### PR DESCRIPTION
This PR turns off coadding for joint fits by default and fixes an LSST API change.

closes #213 