### PR TITLE
Fix failing LSST test

### DIFF
--- a/.github/workflows/lsst-tests-ngmix-upstream.yml
+++ b/.github/workflows/lsst-tests-ngmix-upstream.yml
@@ -11,7 +11,7 @@ jobs:
     name: lsst-tests-ngmix-upstream
     strategy:
       matrix:
-        pyver: ["3.10"]
+        pyver: ["3.11"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: lsst-tests
     strategy:
       matrix:
-        pyver: ["3.10"]
+        pyver: ["3.11"]
 
     runs-on: "ubuntu-latest"
 

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -111,6 +111,7 @@ def detect_and_deblend(
     # the variance
     # detection_config.thresholdType = 'variance'
     detection_config.thresholdValue = thresh
+    detection_config.thresholdType = 'stdev'
 
     # these will be ignored when finding the image standard deviation
     detection_config.statsMask = util.get_stats_mask(detexp)


### PR DESCRIPTION
A few months ago, some of the default values for the detection config were changed in the LSST DM codebase. In particular, [this commit](https://github.com/lsst/meas_algorithms/commit/e63888bc99eeab479a33ce3429d653cd146d50a7) broke one of the tests. The change in the PR is the minimal change required for the tests to pass again.