### PR TITLE
Allow large blends.  Add error fields

### DIFF
--- a/.github/workflows/lsst-tests-ngmix-upstream.yml
+++ b/.github/workflows/lsst-tests-ngmix-upstream.yml
@@ -38,7 +38,7 @@ jobs:
           conda config --set always_yes yes
           mamba install --quiet --yes --file requirements.txt
           mamba install --quiet --yes --file dev-requirements.txt
-          mamba install -q -y stackvana=0 lsstdesc-weaklensingdeblending
+          mamba install -q -y stackvana==0.2024.24 lsstdesc-weaklensingdeblending
 
           pip install --no-deps git+https://github.com/LSSTDESC/descwl-shear-sims.git
           pip install --no-deps git+https://github.com/LSSTDESC/descwl_coadd.git

--- a/.github/workflows/lsst-tests-ngmix-upstream.yml
+++ b/.github/workflows/lsst-tests-ngmix-upstream.yml
@@ -11,7 +11,7 @@ jobs:
     name: lsst-tests-ngmix-upstream
     strategy:
       matrix:
-        pyver: ["3.10"]
+        pyver: ["3.11"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/lsst-tests-ngmix-upstream.yml
+++ b/.github/workflows/lsst-tests-ngmix-upstream.yml
@@ -30,22 +30,21 @@ jobs:
           channel-priority: strict
           show-channel-urls: true
           miniforge-version: latest
-          miniforge-variant: Mambaforge
 
       - name: configure conda and install code
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
-          mamba install --quiet --yes --file requirements.txt
-          mamba install --quiet --yes --file dev-requirements.txt
-          mamba install -q -y stackvana==0.2024.24 lsstdesc-weaklensingdeblending
+          conda install --quiet --yes --file requirements.txt
+          conda install --quiet --yes --file dev-requirements.txt
+          conda install -q -y stackvana=0 lsstdesc-weaklensingdeblending
 
           pip install --no-deps git+https://github.com/LSSTDESC/descwl-shear-sims.git
           pip install --no-deps git+https://github.com/LSSTDESC/descwl_coadd.git
 
           python -m pip install -e .
 
-          mamba uninstall ngmix --force -y
+          conda uninstall ngmix --force -y
           python -m pip install git+https://github.com/esheldon/ngmix.git
 
       - name: test

--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -38,7 +38,8 @@ jobs:
           conda config --set always_yes yes
           mamba install --quiet --yes --file requirements.txt
           mamba install --quiet --yes --file dev-requirements.txt
-          mamba install -q -y stackvana=0 lsstdesc-weaklensingdeblending
+          # mamba install -q -y stackvana=0 lsstdesc-weaklensingdeblending
+          mamba install -q -y stackvana=0.2024.24 lsstdesc-weaklensingdeblending
 
           pip install --no-deps git+https://github.com/LSSTDESC/descwl-shear-sims.git
           pip install --no-deps git+https://github.com/LSSTDESC/descwl_coadd.git

--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -39,7 +39,7 @@ jobs:
           mamba install --quiet --yes --file requirements.txt
           mamba install --quiet --yes --file dev-requirements.txt
           # mamba install -q -y stackvana=0 lsstdesc-weaklensingdeblending
-          mamba install -q -y stackvana=0.2024.24 lsstdesc-weaklensingdeblending
+          mamba install -q -y stackvana=v0.2024.24 lsstdesc-weaklensingdeblending
 
           pip install --no-deps git+https://github.com/LSSTDESC/descwl-shear-sims.git
           pip install --no-deps git+https://github.com/LSSTDESC/descwl_coadd.git

--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -39,7 +39,7 @@ jobs:
           mamba install --quiet --yes --file requirements.txt
           mamba install --quiet --yes --file dev-requirements.txt
           # mamba install -q -y stackvana=0 lsstdesc-weaklensingdeblending
-          mamba install -q -y stackvana=v0.2024.24 lsstdesc-weaklensingdeblending
+          mamba install -q -y stackvana==0.2024.24 lsstdesc-weaklensingdeblending
 
           pip install --no-deps git+https://github.com/LSSTDESC/descwl-shear-sims.git
           pip install --no-deps git+https://github.com/LSSTDESC/descwl_coadd.git

--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -38,7 +38,6 @@ jobs:
           conda install --quiet --yes --file requirements.txt
           conda install --quiet --yes --file dev-requirements.txt
           conda install -q -y stackvana=0 lsstdesc-weaklensingdeblending
-          # conda install -q -y stackvana==0.2024.24 lsstdesc-weaklensingdeblending
 
           pip install --no-deps git+https://github.com/LSSTDESC/descwl-shear-sims.git
           pip install --no-deps git+https://github.com/LSSTDESC/descwl_coadd.git

--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -30,16 +30,15 @@ jobs:
           channel-priority: strict
           show-channel-urls: true
           miniforge-version: latest
-          miniforge-variant: Mambaforge
 
       - name: configure conda and install code
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
-          mamba install --quiet --yes --file requirements.txt
-          mamba install --quiet --yes --file dev-requirements.txt
-          # mamba install -q -y stackvana=0 lsstdesc-weaklensingdeblending
-          mamba install -q -y stackvana==0.2024.24 lsstdesc-weaklensingdeblending
+          conda install --quiet --yes --file requirements.txt
+          conda install --quiet --yes --file dev-requirements.txt
+          conda install -q -y stackvana=0 lsstdesc-weaklensingdeblending
+          # conda install -q -y stackvana==0.2024.24 lsstdesc-weaklensingdeblending
 
           pip install --no-deps git+https://github.com/LSSTDESC/descwl-shear-sims.git
           pip install --no-deps git+https://github.com/LSSTDESC/descwl_coadd.git

--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: lsst-tests
     strategy:
       matrix:
-        pyver: ["3.10"]
+        pyver: ["3.11"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/shear_test.yml
+++ b/.github/workflows/shear_test.yml
@@ -25,14 +25,13 @@ jobs:
           channel-priority: strict
           show-channel-urls: true
           miniforge-version: latest
-          miniforge-variant: Mambaforge
 
       - name: configure conda and install code
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
-          mamba install --quiet --yes --file requirements.txt
-          mamba install --quiet --yes --file dev-requirements.txt
+          conda install --quiet --yes --file requirements.txt
+          conda install --quiet --yes --file dev-requirements.txt
 
           conda uninstall ngmix --force -y
           pip install git+https://github.com/esheldon/ngmix.git

--- a/.github/workflows/tests-ngmix-upstream.yml
+++ b/.github/workflows/tests-ngmix-upstream.yml
@@ -30,14 +30,13 @@ jobs:
           channel-priority: strict
           show-channel-urls: true
           miniforge-version: latest
-          miniforge-variant: Mambaforge
 
       - name: configure conda and install code
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
-          mamba install --quiet --yes --file requirements.txt
-          mamba install --quiet --yes --file dev-requirements.txt
+          conda install --quiet --yes --file requirements.txt
+          conda install --quiet --yes --file dev-requirements.txt
 
           python -m pip install -e .
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,14 +30,13 @@ jobs:
           channel-priority: strict
           show-channel-urls: true
           miniforge-version: latest
-          miniforge-variant: Mambaforge
 
       - name: configure conda and install code
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
-          mamba install --quiet --yes --file requirements.txt
-          mamba install --quiet --yes --file dev-requirements.txt
+          conda install --quiet --yes --file requirements.txt
+          conda install --quiet --yes --file dev-requirements.txt
 
           python -m pip install -e .
 

--- a/metadetect/fitting.py
+++ b/metadetect/fitting.py
@@ -1056,10 +1056,14 @@ def _sum_bands_wavg(
                 # weight function to peak at 1 for flux measurements (and only care
                 # about the object).
 
-                raw_mom += (wgt * flux_mom_ratio / mom_norm * res[MOMNAME])
+                # we added an extra sum for AM, for rho4
+                rmoms = res[MOMNAME][:raw_mom.size]
+                rcovs = res[MOMNAME + '_cov'][:raw_mom.size, :raw_mom.size]
+
+                raw_mom += (wgt * flux_mom_ratio / mom_norm * rmoms)
                 raw_mom_cov += (
                     (wgt * flux_mom_ratio / mom_norm)**2
-                    * res[MOMNAME+"_cov"]
+                    * rcovs
                 )
                 wgt_sum += wgt
 

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -125,7 +125,7 @@ def detect_and_deblend(
 
     detection_config.nPeaksMaxSimple = 1
     detection_config.nSigmaForKernel = 7.0
-    detection_config.excludeMaskPlanes = []
+    detection_config.excludeMaskPlanes = util.get_detection_mask(detexp)
 
     # the defaults changed from from stdev to pixel_std but
     # we don't want that

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -101,6 +101,8 @@ def detect_and_deblend(
         config=meas_config,
         schema=schema,
     )
+    # avoids a warning spamming for every object
+    afw_table.CoordKey.addErrorFields(schema)
 
     detection_config = SourceDetectionConfig()
     detection_config.reEstimateBackground = False

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -123,18 +123,16 @@ def detect_and_deblend(
     # other tasks using the same schema are run because schema is modified in
     # place by tasks, and the constructor does a check that fails if we do this
     # afterward
-
+    deblend_config = SourceDeblendConfig()
+    deblend_config.maxFootprintArea = 0
     deblend_task = SourceDeblendTask(
-        config=SourceDeblendConfig(),
+        config=deblend_config,
         schema=schema,
     )
 
     table = afw_table.SourceTable.make(schema)
 
     result = detection_task.run(table, detexp)
-
-    if show:
-        vis.show_exp(detexp)
 
     if result is not None:
         sources = result.sources
@@ -154,6 +152,9 @@ def detect_and_deblend(
 
     else:
         sources = []
+
+    if show:
+        vis.show_exp(detexp, use_mpl=True, sources=sources)
 
     return sources, detexp
 

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -105,13 +105,35 @@ def detect_and_deblend(
     afw_table.CoordKey.addErrorFields(schema)
 
     detection_config = SourceDetectionConfig()
+
+    # DM does not have config default stability.  Set all of them explicitly
+    detection_config.minPixels = 1
+    detection_config.isotropicGrow = True
+    detection_config.combinedGrow = True
+    detection_config.nSigmaToGrow = 2.4
+    detection_config.returnOriginalFootprints = False
+    detection_config.includeThresholdMultiplier = 1.0
+    detection_config.thresholdPolarity = "positive"
+    detection_config.adjustBackground = 0.0
+    detection_config.reEstimateBackground = True
+    # these are ignored since we are doing reEstimateBackground = False
+    # detection_config.background
+    # detection_config.tempLocalBackground
+    # detection_config.doTempLocalBackground
+    # detection_config.tempWideBackground
+    # detection_config.doTempWideBackground
+
+    detection_config.nPeaksMaxSimple = 1
+    detection_config.nSigmaForKernel = 7.0
+    detection_config.excludeMaskPlanes = []
+
+    # the defaults changed from from stdev to pixel_std but
+    # we don't want that
+
+    detection_config.thresholdType = "stdev"
+    # our changes from defaults
     detection_config.reEstimateBackground = False
-    # variance here actually means relative to the sqrt(variance)
-    # from the variance plane.
-    # TODO this would include poisson
-    # TODO detection doesn't work right when we tell it to trust
-    # the variance
-    # detection_config.thresholdType = 'variance'
+
     detection_config.thresholdValue = thresh
 
     # these will be ignored when finding the image standard deviation

--- a/metadetect/lsst/metacal_exposures.py
+++ b/metadetect/lsst/metacal_exposures.py
@@ -146,7 +146,7 @@ def get_metacal_exps(exp, types=None, rot=False):
     # wcs = exp.getWcs()
 
     gwcs = get_galsim_jacobian_wcs(exp=exp, cen=cen)
-    pixel = gwcs.toWorld(galsim.Pixel(scale=1))
+    # pixel = gwcs.toWorld(galsim.Pixel(scale=1))
     # pixel_inv = galsim.Deconvolve(pixel)
 
     psf_image_array = get_psf_kernel_image(exp=exp, cen=cen)
@@ -176,8 +176,9 @@ def get_metacal_exps(exp, types=None, rot=False):
     gauss_psf = _get_gauss_target_psf(psf_int, flux=psf_flux)
 
     dilation = 1.0 + 2.0*STEP
-    psf_dilated_nopix = gauss_psf.dilate(dilation)
-    psf_dilated = galsim.Convolve(psf_dilated_nopix, pixel)
+    # psf_dilated_nopix = gauss_psf.dilate(dilation)
+    # psf_dilated = galsim.Convolve(psf_dilated_nopix, pixel)
+    psf_dilated = gauss_psf.dilate(dilation)
 
     psf_dilated_image = psf_image.copy()
     psf_dilated.drawImage(image=psf_dilated_image, method='no_pixel')

--- a/metadetect/lsst/metacal_exposures.py
+++ b/metadetect/lsst/metacal_exposures.py
@@ -143,11 +143,7 @@ def get_metacal_exps(exp, types=None, rot=False):
 
     cen, _ = get_integer_center(exp.getWcs(), exp.getBBox(), as_double=True)
 
-    # wcs = exp.getWcs()
-
     gwcs = get_galsim_jacobian_wcs(exp=exp, cen=cen)
-    # pixel = gwcs.toWorld(galsim.Pixel(scale=1))
-    # pixel_inv = galsim.Deconvolve(pixel)
 
     psf_image_array = get_psf_kernel_image(exp=exp, cen=cen)
     psf_flux = psf_image_array.sum()
@@ -171,13 +167,9 @@ def get_metacal_exps(exp, types=None, rot=False):
         galsim.Deconvolve(psf_int),
     )
 
-    # psf_int_nopix = galsim.Convolve([psf_int, pixel_inv])
-    # gauss_psf = _get_gauss_target_psf(psf_int_nopix, flux=psf_flux)
     gauss_psf = _get_gauss_target_psf(psf_int, flux=psf_flux)
 
     dilation = 1.0 + 2.0*STEP
-    # psf_dilated_nopix = gauss_psf.dilate(dilation)
-    # psf_dilated = galsim.Convolve(psf_dilated_nopix, pixel)
     psf_dilated = gauss_psf.dilate(dilation)
 
     psf_dilated_image = psf_image.copy()

--- a/metadetect/lsst/metacal_exposures.py
+++ b/metadetect/lsst/metacal_exposures.py
@@ -147,7 +147,7 @@ def get_metacal_exps(exp, types=None, rot=False):
 
     gwcs = get_galsim_jacobian_wcs(exp=exp, cen=cen)
     pixel = gwcs.toWorld(galsim.Pixel(scale=1))
-    pixel_inv = galsim.Deconvolve(pixel)
+    # pixel_inv = galsim.Deconvolve(pixel)
 
     psf_image_array = get_psf_kernel_image(exp=exp, cen=cen)
     psf_flux = psf_image_array.sum()
@@ -171,9 +171,9 @@ def get_metacal_exps(exp, types=None, rot=False):
         galsim.Deconvolve(psf_int),
     )
 
-    psf_int_nopix = galsim.Convolve([psf_int, pixel_inv])
-
-    gauss_psf = _get_gauss_target_psf(psf_int_nopix, flux=psf_flux)
+    # psf_int_nopix = galsim.Convolve([psf_int, pixel_inv])
+    # gauss_psf = _get_gauss_target_psf(psf_int_nopix, flux=psf_flux)
+    gauss_psf = _get_gauss_target_psf(psf_int, flux=psf_flux)
 
     dilation = 1.0 + 2.0*STEP
     psf_dilated_nopix = gauss_psf.dilate(dilation)

--- a/metadetect/lsst/tests/test_lsst_dm_configs.py
+++ b/metadetect/lsst/tests/test_lsst_dm_configs.py
@@ -1,0 +1,33 @@
+from lsst.meas.algorithms import SourceDetectionConfig
+
+
+def test_detect_config():
+    expected_keys = [
+        'minPixels',
+        'isotropicGrow',
+        'combinedGrow',
+        'nSigmaToGrow',
+        'returnOriginalFootprints',
+        'thresholdValue',
+        'includeThresholdMultiplier',
+        'thresholdType',
+        'thresholdPolarity',
+        'adjustBackground',
+        'reEstimateBackground',
+        'background',
+        'tempLocalBackground',
+        'doTempLocalBackground',
+        'tempWideBackground',
+        'doTempWideBackground',
+        'nPeaksMaxSimple',
+        'nSigmaForKernel',
+        'statsMask',
+        'excludeMaskPlanes'
+    ]
+
+    config = SourceDetectionConfig()
+
+    keys = config.toDict().keys()
+
+    for key in keys:
+        assert key in expected_keys, f'found unexpected config key {key}'

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -341,7 +341,6 @@ def test_lsst_masked_as_bright(show=False):
     seed = 55
     afw_image.Mask.addMaskPlane('BRIGHT')
     bright = afw_image.Mask.getPlaneBitMask('BRIGHT')
-    print('bright:', bright)
     for do_zero in [False, True]:
         rng = np.random.RandomState(seed)
         sim_data = make_lsst_sim(seed, mag=23)

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -442,6 +442,7 @@ def test_lsst_metadetect_mfrac_ormask(show=False):
 
 
 if __name__ == '__main__':
-    test_lsst_masked_as_bright(show=True)
+    test_lsst_metadetect_am()
+    # test_lsst_masked_as_bright(show=True)
     # test_lsst_metadetect_smoke('wmom', 'False')
     # test_lsst_metadetect_mfrac_ormask(show=True)

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -297,8 +297,11 @@ def test_lsst_metadetect_fullcoadd_smoke():
 
 def test_lsst_zero_weights(show=False):
     """
-    To make sure in the case of inf variance but not marked as bright
-    we are detecting (should not happen)
+    At time of writing, DM stack will still detect in regions with inf
+    variance.  Test this continues to be true.
+
+    However, we don't have detections in BRIGHT, see test
+    test_lsst_masked_as_bright
     """
     nobj = []
     seed = 55

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -307,14 +307,22 @@ def test_lsst_zero_weights(show=False):
             data['mbexp']['i'].variance.array[50:100, 50:100] = np.inf
             data['noise_mbexp']['i'].variance.array[50:100, 50:100] = np.inf
 
-            if show:
-                import matplotlib.pyplot as mplt
-                fig, axs = mplt.subplots(ncols=2)
-                axs[0].imshow(data['mbexp']['i'].image.array)
-                axs[1].imshow(data['mbexp']['i'].variance.array)
-                mplt.show()
-
         resdict = run_metadetect(rng=rng, config=None, **data)
+
+        if show:
+            import matplotlib.pyplot as mplt
+            fig, axs = mplt.subplots(ncols=2)
+            axs[0].imshow(data['mbexp']['i'].image.array)
+            axs[1].imshow(data['mbexp']['i'].variance.array)
+
+            axs[0].scatter(
+                resdict['noshear']['col'] - resdict['noshear']['col0'],
+                resdict['noshear']['row'] - resdict['noshear']['row0'],
+                s=4,
+                c='red',
+            )
+            mplt.show()
+            # import IPython; IPython.embed()
 
         if do_zero:
             for shear_type, tres in resdict.items():
@@ -395,6 +403,6 @@ def test_lsst_metadetect_mfrac_ormask(show=False):
 
 
 if __name__ == '__main__':
-    # test_lsst_zero_weights(show=True)
+    test_lsst_zero_weights(show=True)
     # test_lsst_metadetect_smoke('wmom', 'False')
-    test_lsst_metadetect_mfrac_ormask(show=True)
+    # test_lsst_metadetect_mfrac_ormask(show=True)

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -335,7 +335,9 @@ def test_lsst_zero_weights(show=False):
 
 
 def test_lsst_masked_as_bright(show=False):
-    nobj = []
+    """
+    Make sure we don't detect in areas marked BRIGHT
+    """
     seed = 55
     afw_image.Mask.addMaskPlane('BRIGHT')
     bright = afw_image.Mask.getPlaneBitMask('BRIGHT')
@@ -365,7 +367,6 @@ def test_lsst_masked_as_bright(show=False):
                 c='red',
             )
             mplt.show()
-            # import IPython; IPython.embed()
 
         if do_zero:
             for shear_type, tres in resdict.items():
@@ -374,10 +375,6 @@ def test_lsst_masked_as_bright(show=False):
             for shear_type, tres in resdict.items():
                 # 5x5 grid
                 assert tres.size == 25
-
-        nobj.append(resdict['noshear'].size)
-
-    # assert nobj[0] == nobj[1]
 
 
 @pytest.mark.parametrize('meas_type', ['ksigma', 'pgauss'])

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -341,6 +341,7 @@ def test_lsst_masked_as_bright(show=False):
     seed = 55
     afw_image.Mask.addMaskPlane('BRIGHT')
     bright = afw_image.Mask.getPlaneBitMask('BRIGHT')
+    print('bright:', bright)
     for do_zero in [False, True]:
         rng = np.random.RandomState(seed)
         sim_data = make_lsst_sim(seed, mag=23)
@@ -370,7 +371,7 @@ def test_lsst_masked_as_bright(show=False):
 
         if do_zero:
             for shear_type, tres in resdict.items():
-                assert tres.size == 25
+                assert tres.size == 24
         else:
             for shear_type, tres in resdict.items():
                 # 5x5 grid
@@ -442,7 +443,7 @@ def test_lsst_metadetect_mfrac_ormask(show=False):
 
 
 if __name__ == '__main__':
-    test_lsst_metadetect_am()
-    # test_lsst_masked_as_bright(show=True)
+    # test_lsst_metadetect_am()
+    test_lsst_masked_as_bright(show=True)
     # test_lsst_metadetect_smoke('wmom', 'False')
     # test_lsst_metadetect_mfrac_ormask(show=True)

--- a/metadetect/lsst/util.py
+++ b/metadetect/lsst/util.py
@@ -827,11 +827,14 @@ def get_stats_mask(exp):
 
 def get_detection_mask(exp):
     """
-    Get a mask for detection, regions with these
-    flags will not be searched for objects. If BRIGHT
-    is found in the mask plane it is added to the usual
+    Get a mask for detection. Regions with these flags set will not be searched
+    for objects.
 
-    ['EDGE', 'NO_DATA']
+    Default is ['EDGE', 'NO_DATA']
+
+    BRIGHT is defined in descwl_coadd, so it is not guaranteed to be present in
+    the global mask bit space.  Only add BRIGHT to detection mask BRIGHT if it
+    is found in the global mask plane dict
 
     Parameters
     ----------

--- a/metadetect/lsst/util.py
+++ b/metadetect/lsst/util.py
@@ -825,6 +825,35 @@ def get_stats_mask(exp):
     return stats_mask
 
 
+def get_detection_mask(exp):
+    """
+    Get a mask for detection, regions with these
+    flags will not be searched for objects. If BRIGHT
+    is found in the mask plane it is added to the usual
+
+    ['EDGE', 'NO_DATA']
+
+    Parameters
+    ----------
+    exp: lsst.afw.image.ExposureF
+        The exposure
+
+    Returns
+    -------
+    A list of mask planes
+    """
+
+    # these will be ignored when finding the image standard deviation
+    # stats_mask = ['BAD', 'SAT', 'EDGE', 'NO_DATA']
+
+    mask = ['EDGE', 'NO_DATA']
+
+    if 'BRIGHT' in exp.mask.getMaskPlaneDict():
+        mask += ['BRIGHT']
+
+    return mask
+
+
 def extract_multiband_coadd_data(coadd_data_list):
     """
     Convert a list of coadd data for a set of bands into MultibandExposure data

--- a/metadetect/lsst/util.py
+++ b/metadetect/lsst/util.py
@@ -846,9 +846,6 @@ def get_detection_mask(exp):
     A list of mask planes
     """
 
-    # these will be ignored when finding the image standard deviation
-    # stats_mask = ['BAD', 'SAT', 'EDGE', 'NO_DATA']
-
     mask = ['EDGE', 'NO_DATA']
 
     if 'BRIGHT' in exp.mask.getMaskPlaneDict():

--- a/metadetect/lsst/vis.py
+++ b/metadetect/lsst/vis.py
@@ -9,7 +9,7 @@ COLOR = 'red'
 EDGECOLOR = 'white'
 
 
-def show_exp(exp, mess=None):
+def show_exp(exp, mess=None, use_mpl=False, sources=None):
     """
     show the image in ds9
 
@@ -20,17 +20,51 @@ def show_exp(exp, mess=None):
     mess: str, optional
         A message to use as title to plot
     """
+    import matplotlib.pyplot as mplt
     import lsst.afw.display as afw_display
 
-    display = afw_display.getDisplay(backend='ds9')
-    display.mtv(exp)
-    display.scale('log', 'minmax')
+    if use_mpl:
+        fig, axs = mplt.subplots(ncols=3)
+        image = exp.image.array
 
-    prompt = 'hit enter'
-    if mess is not None:
-        prompt = '%s: (%s)' % (mess, prompt)
+        noise = np.sqrt(np.median(exp.variance.array))
 
-    input(prompt)
+        noise = np.sqrt(np.median(exp.variance.array))
+        minval = 0.1 * noise
+        axs[0].imshow(np.log(image.clip(min=minval)))
+
+        axs[1].imshow(exp.variance.array)
+        axs[1].set_title('variance')
+
+        axs[2].imshow(exp.mask.array)
+        axs[2].set_title('mask')
+
+        if sources is not None:
+            from pprint import pprint
+            bbox = exp.getBBox()
+            pprint(exp.mask.getMaskPlaneDict())
+            axs[0].scatter(
+                sources['base_SdssCentroid_x'] - bbox.beginX,
+                sources['base_SdssCentroid_y'] - bbox.beginY,
+                color='red',
+            )
+
+        if mess is not None:
+            axs.suptitle(mess)
+
+        mplt.show()
+
+    else:
+
+        display = afw_display.getDisplay(backend='ds9')
+        display.mtv(exp)
+        display.scale('log', 'minmax')
+
+        prompt = 'hit enter'
+        if mess is not None:
+            prompt = '%s: (%s)' % (mess, prompt)
+
+        input(prompt)
 
 
 def show_mbexp(

--- a/metadetect/lsst/vis.py
+++ b/metadetect/lsst/vis.py
@@ -50,7 +50,7 @@ def show_exp(exp, mess=None, use_mpl=False, sources=None):
             )
 
         if mess is not None:
-            axs.suptitle(mess)
+            fig.suptitle(mess)
 
         mplt.show()
 


### PR DESCRIPTION
* set the deblend config to allow large blends
* set afw_table.CoordKey.addErrorFields(schema) to avoid getting spammed by warnings

This deblending change is important.  It should result in a lot more detections in blended regions, and it potentially requires a full retesting.

We might be happy retesting in "no warp" mode, direct to coadd simulations, which would speed it up by a factor of perhaps 2.5