### PR TITLE
Enable lsst metadetect to read mcal types in config

### DIFF
--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -74,8 +74,13 @@ def run_metadetect(
 
     fitter = get_fitter(config, rng=rng)
 
+    if 'types' in config['metacal']:
+        metacal_types = config['metacal']['types']
+    else:
+        metacal_types = None
+
     mdict, noise_mdict = get_metacal_mbexps_fixnoise(
-        mbexp=mbexp, noise_mbexp=noise_mbexp, types=config['metacal']['types'],
+        mbexp=mbexp, noise_mbexp=noise_mbexp, types=metacal_types,
     )
 
     result = {}

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -74,10 +74,7 @@ def run_metadetect(
 
     fitter = get_fitter(config, rng=rng)
 
-    if 'types' in config['metacal']:
-        metacal_types = config['metacal']['types']
-    else:
-        metacal_types = None
+    metacal_types = config['metacal'].get('types', None)
 
     mdict, noise_mdict = get_metacal_mbexps_fixnoise(
         mbexp=mbexp, noise_mbexp=noise_mbexp, types=metacal_types,

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -75,7 +75,7 @@ def run_metadetect(
     fitter = get_fitter(config, rng=rng)
 
     mdict, noise_mdict = get_metacal_mbexps_fixnoise(
-        mbexp=mbexp, noise_mbexp=noise_mbexp,
+        mbexp=mbexp, noise_mbexp=noise_mbexp, types=config['metacal']['types'],
     )
 
     result = {}

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -88,7 +88,8 @@ def do_coadding(rng, sim_data, nowarp):
 
 @pytest.mark.parametrize('meas_type', [None, 'wmom', 'ksigma', 'pgauss'])
 @pytest.mark.parametrize('subtract_sky', [None, False, True])
-def test_lsst_metadetect_smoke(meas_type, subtract_sky):
+@pytest.mark.parametrize("metacal_types_option", [None, "1p1m", "full"])
+def test_lsst_metadetect_smoke(meas_type, subtract_sky, metacal_types_option):
     rng = np.random.RandomState(seed=116)
 
     bands = ['r', 'i']
@@ -103,11 +104,25 @@ def test_lsst_metadetect_smoke(meas_type, subtract_sky):
     if meas_type is not None:
         config['meas_type'] = meas_type
 
+    if metacal_types_option is not None:
+        if metacal_types_option == "1p1m":
+            metacal_types = ['noshear', '1p', '1m']
+            config['metacal'] = {}
+        elif metacal_types_option == "full":
+            metacal_types = ['noshear', '1p', '1m', '2p', '2m']
+            config['metacal'] = {}
+        config['metacal']['types'] = metacal_types
+    else:
+        metacal_types = ['noshear', '1p', '1m']
+
     detected = afw_image.Mask.getPlaneBitMask('DETECTED')
     res = run_metadetect(rng=rng, config=config, **data)
 
     # we remove the DETECTED bit
     assert np.all(res['noshear']['bmask'] & detected == 0)
+
+    for metacal_type in metacal_types:
+        assert metacal_type in res.keys(), f"metacal_type={metacal_type} not in res.keys()"
 
     if meas_type is None:
         front = 'wmom'
@@ -118,7 +133,7 @@ def test_lsst_metadetect_smoke(meas_type, subtract_sky):
     flux_name = f'{front}_band_flux'
     assert gname in res['noshear'].dtype.names
 
-    for shear in ('noshear', '1p', '1m'):
+    for shear in metacal_types:
         # 5x5 grid
         assert res[shear].size == 25
 

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -124,7 +124,7 @@ def test_lsst_metadetect_smoke(meas_type, subtract_sky, metacal_types_option):
     for metacal_type in metacal_types:
         assert (
             metacal_type in res.keys()
-            ), f"metacal_type={metacal_type} not in res.keys()"
+        ), f"metacal_type={metacal_type} not in res.keys()"
 
     if meas_type is None:
         front = 'wmom'

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -122,7 +122,9 @@ def test_lsst_metadetect_smoke(meas_type, subtract_sky, metacal_types_option):
     assert np.all(res['noshear']['bmask'] & detected == 0)
 
     for metacal_type in metacal_types:
-        assert metacal_type in res.keys(), f"metacal_type={metacal_type} not in res.keys()"
+        assert (
+            metacal_type in res.keys()
+            ), f"metacal_type={metacal_type} not in res.keys()"
 
     if meas_type is None:
         front = 'wmom'


### PR DESCRIPTION
Hi!

Currently, mdet only uses the DEFAULT_TYPES instead of reading the mcal types in the config file. In cluster shear calibration R11 and R22 are needed. 