### PR TITLE
Make input optional for get_detection_mask

### DIFF
--- a/metadetect/lsst/util.py
+++ b/metadetect/lsst/util.py
@@ -825,7 +825,7 @@ def get_stats_mask(exp):
     return stats_mask
 
 
-def get_detection_mask(exp):
+def get_detection_mask(exp=None):
     """
     Get a mask for detection. Regions with these flags set will not be searched
     for objects.
@@ -838,7 +838,7 @@ def get_detection_mask(exp):
 
     Parameters
     ----------
-    exp: lsst.afw.image.ExposureF
+    exp: lsst.afw.image.ExposureF, optional
         The exposure
 
     Returns
@@ -848,7 +848,7 @@ def get_detection_mask(exp):
 
     mask = ['EDGE', 'NO_DATA']
 
-    if 'BRIGHT' in exp.mask.getMaskPlaneDict():
+    if exp is not None and 'BRIGHT' in exp.mask.getMaskPlaneDict():
         mask += ['BRIGHT']
 
     return mask


### PR DESCRIPTION
In #218 , @esheldon introduced `get_detection_mask` function, which sets the config depending on the Exposure data. This interferes with the upcoming refactoring indicated in #220 , since config values must be set before any data is processed. The minimally distruptive solution seems to be making the input argument optional. Based on [this](https://github.com/LSSTDESC/descwl_coadd/issues/58), `BRIGHT` mask plane is also deprecated, so I don't expect any issues because of not providing the input argument.