### PR TITLE
Compatibility with numpy 2 and recent stack versions

### DIFF
--- a/.github/workflows/lsst-tests-ngmix-upstream.yml
+++ b/.github/workflows/lsst-tests-ngmix-upstream.yml
@@ -11,7 +11,7 @@ jobs:
     name: lsst-tests-ngmix-upstream
     strategy:
       matrix:
-        pyver: ["3.11"]
+        pyver: ["3.12"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: lsst-tests
     strategy:
       matrix:
-        pyver: ["3.11"]
+        pyver: ["3.12"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/shear_test.yml
+++ b/.github/workflows/shear_test.yml
@@ -11,7 +11,7 @@ jobs:
     name: shear-tests
     strategy:
       matrix:
-        pyver: ["3.10"]
+        pyver: ["3.12"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/tests-ngmix-upstream.yml
+++ b/.github/workflows/tests-ngmix-upstream.yml
@@ -11,7 +11,7 @@ jobs:
     name: tests-ngmix-upstream
     strategy:
       matrix:
-        pyver: ["3.9", "3.10"]
+        pyver: ["3.9", "3.10", "3.11", "3.12"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: tests
     strategy:
       matrix:
-        pyver: ["3.9", "3.10"]
+        pyver: ["3.9", "3.10", "3.11", "3.12"]
 
     runs-on: "ubuntu-latest"
 

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -102,6 +102,7 @@ class DetectAndDeblendConfig(Config):
         self.detect.includeThresholdMultiplier = 1.0
         self.detect.thresholdPolarity = "positive"
         self.detect.adjustBackground = 0.0
+        self.detect.doApplyFlatBackgroundRatio = False
         # these are ignored since we are doing reEstimateBackground = False
         # detection_config.background
         # detection_config.tempLocalBackground

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -567,7 +567,7 @@ def extract_psf_image(exposure, orig_cen):
     except InvalidParameterError:
         raise MissingDataError("could not reconstruct PSF")
 
-    psfim = np.array(psfim, dtype='f4', copy=False)
+    psfim = np.asarray(psfim, dtype='f4')
 
     shape = psfim.shape
     assert shape[0] == shape[1], 'require square psf images'
@@ -593,7 +593,7 @@ def _extract_psf_image_fix(exposure, orig_cen):
     except InvalidParameterError:
         raise MissingDataError("could not reconstruct PSF")
 
-    psfim = np.array(psfim, dtype='f4', copy=False)
+    psfim = np.asarray(psfim, dtype='f4')
 
     psfim = util.trim_odd_image(psfim)
     return psfim

--- a/metadetect/lsst/tests/test_lsst_dm_configs.py
+++ b/metadetect/lsst/tests/test_lsst_dm_configs.py
@@ -22,7 +22,8 @@ def test_detect_config():
         'nPeaksMaxSimple',
         'nSigmaForKernel',
         'statsMask',
-        'excludeMaskPlanes'
+        'excludeMaskPlanes',
+        'doApplyFlatBackgroundRatio',
     ]
 
     config = SourceDetectionConfig()


### PR DESCRIPTION
The changes should be hopefully straightforward. They include compatibility with numpy 2 and minor modifications to make it work with more recent versions of the stack(-vana).