### PR TITLE
Remove now unnecessary addErrorFields

### DIFF
--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -162,7 +162,6 @@ class DetectAndDeblendTask(Task):
             detexp = afw_image.ExposureF(detexp, deep=True)
 
         schema = self.deblend.schema  # should be the same for all tasks
-        afw_table.CoordKey.addErrorFields(schema)
         table = afw_table.SourceTable.make(schema)
         result = self.detect.run(table, detexp)
 


### PR DESCRIPTION
This is handled inside the SkyCoord plugin automatically since w_2025_24 or so. Trying to add this again results in an error.