### PR TITLE
Pass deblender configs

### DIFF
--- a/metadetect/_version.py
+++ b/metadetect/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.13.0'  # noqa
+__version__ = '0.13.1'  # noqa

--- a/metadetect/lsst/defaults.py
+++ b/metadetect/lsst/defaults.py
@@ -26,11 +26,22 @@ DEFAULT_DETECT_CONFIG = {
     'thresh': DEFAULT_THRESH,
 }
 
+# deblender config
+DEFAULT_DEBLEND_SDSS_CONFIG = {
+    'name': 'sdss',
+    'maxFootprintArea': 0,
+}
+
+DEFAULT_DEBLEND_SCARLET_CONFIG = {
+    'name': 'scarlet',
+    'processSingles': True,
+    'maxFootprintArea': 0,
+}
 # the pgauss subconfig and the stamp_size defaults we be filled in
 # programatically based on the measurement_type
 DEFAULT_MDET_CONFIG = {
     'subtract_sky': DEFAULT_SUBTRACT_SKY,
-    'deblender': 'sdss',
+    'deblend': deepcopy(DEFAULT_DEBLEND_SDSS_CONFIG),
     'detect': deepcopy(DEFAULT_DETECT_CONFIG),
     'metacal': deepcopy(DEFAULT_METACAL_CONFIG),
     'pgauss': deepcopy(DEFAULT_PGAUSS_CONFIG),

--- a/metadetect/lsst/defaults.py
+++ b/metadetect/lsst/defaults.py
@@ -41,7 +41,10 @@ DEFAULT_DEBLEND_SCARLET_CONFIG = {
 # programatically based on the measurement_type
 DEFAULT_MDET_CONFIG = {
     'subtract_sky': DEFAULT_SUBTRACT_SKY,
-    'deblend': deepcopy(DEFAULT_DEBLEND_SDSS_CONFIG),
+    'detect_and_deblend': {
+        'detect': deepcopy(DEFAULT_DETECT_CONFIG),
+        'deblend': deepcopy(DEFAULT_DEBLEND_SDSS_CONFIG),
+    },
     'detect': deepcopy(DEFAULT_DETECT_CONFIG),
     'metacal': deepcopy(DEFAULT_METACAL_CONFIG),
     'pgauss': deepcopy(DEFAULT_PGAUSS_CONFIG),

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -297,12 +297,12 @@ def get_detect_and_deblend_task(
         config_override['detect']['thresholdValue'] = thresh
 
     config = DetectAndDeblendConfig()
+    config.setDefaults()
 
     if deblender == "scarlet":
         config.deblend.retarget(ScarletDeblendTask)
         config.deblend.processSingles = True
 
-    config.setDefaults()
 
     util.override_config(config, config_override)
 

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -267,7 +267,7 @@ class DetectAndDeblendTask(Task):
 def get_detect_and_deblend_task(
     rng=None,
     thresh=DEFAULT_THRESH,
-    deblender="sdss",
+    deblender=None,
     config=None,
 ):
     """
@@ -292,6 +292,12 @@ def get_detect_and_deblend_task(
     sources, detexp
         The sources and the detection exposure
     """
+    if deblender is not None:
+        LOG.warning(
+            "'deblender' kwargs is not used and will be removed soon. "
+            "Specify the deblender via the config kwarg instead."
+        )
+
     config_override = config if config is not None else {}
     if thresh:
         if 'detect' not in config_override:

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -193,7 +193,7 @@ class DetectAndDeblendTask(Task):
 
         if isinstance(self.deblend, ScarletDeblendTask):
             LOG.info('Using Scarlet deblender')
-            sources, model_data = self._run_with_scarlet(mbexp, detexp, sources)
+            sources, model_data = self._run_with_scarlet(mbexp, sources)
         else:
             LOG.info('Using SDSS deblender')
             model_data = None

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -284,6 +284,8 @@ def get_detect_and_deblend_task(
         Random number generator for noise replacer
     thresh: float, optional
         The detection threshold in units of the sky noise
+    config: dict, optional
+        The configuration dictionary to override the defaults with.
 
     Returns
     -------
@@ -299,10 +301,8 @@ def get_detect_and_deblend_task(
     config = DetectAndDeblendConfig()
     config.setDefaults()
 
-    if deblender == "scarlet":
+    if config_override.get('deblend', {}).pop('name', '') == "scarlet":
         config.deblend.retarget(ScarletDeblendTask)
-        config.deblend.processSingles = True
-
 
     util.override_config(config, config_override)
 

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -170,6 +170,7 @@ class DetectAndDeblendTask(Task):
         self.makeSubtask("detect", schema=schema)
         self.makeSubtask("deblend", schema=schema)
         self.rng = np.random.RandomState(seed=self.config.seed)
+        self.schema = schema
 
     def run(self, mbexp, show=False):
         if len(mbexp.singles) > 1:
@@ -183,26 +184,29 @@ class DetectAndDeblendTask(Task):
         if not isinstance(detexp, afw_image.ExposureF):
             detexp = afw_image.ExposureF(detexp, deep=True)
 
+        table = afw_table.SourceTable.make(self.schema)
+        result = self.detect.run(table, detexp)
+        if result is not None:
+            sources = result.sources
+        else:
+            sources = []
+
         if isinstance(self.deblend, ScarletDeblendTask):
             LOG.info('Using Scarlet deblender')
-            sources, model_data = self._run_with_scarlet(mbexp, detexp)
+            sources, model_data = self._run_with_scarlet(mbexp, detexp, sources)
         else:
             LOG.info('Using SDSS deblender')
             model_data = None
-            sources = self._run_with_sdss(detexp)
+            sources = self._run_with_sdss(detexp, sources)
 
         if show:
             vis.show_exp(detexp, use_mpl=True, sources=sources)
 
         return sources, detexp, model_data
 
-    def _run_with_sdss(self, detexp):
-        schema = self.deblend.schema  # should be the same for all tasks
-        table = afw_table.SourceTable.make(schema)
-        result = self.detect.run(table, detexp)
+    def _run_with_sdss(self, detexp, sources):
 
-        if result is not None:
-            sources = result.sources
+        if len(sources) > 0:
             self.deblend.run(detexp, sources)
 
             # with ContextNoiseReplacer(
@@ -225,14 +229,9 @@ class DetectAndDeblendTask(Task):
 
         return sources
 
-    def _run_with_scarlet(self, mbexp, detexp):
-        schema = self.deblend.objectSchema  # should be the same for all tasks
-        table = afw_table.SourceTable.make(schema)
-        result = self.detect.run(table, detexp)
+    def _run_with_scarlet(self, mbexp, orig_sources):
 
-        if result is not None:
-            orig_sources = result.sources
-
+        if len(orig_sources) > 0:
             mbexp_deconvolved = util.make_deconvolved_mbexp(
                 mbexp, orig_sources,
             )

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -263,62 +263,6 @@ class DetectAndDeblendTask(Task):
         return sources, model_data
 
 
-def get_detect_and_deblend_task(
-    rng=None,
-    thresh=DEFAULT_THRESH,
-    deblender=None,
-    config=None,
-):
-    """
-    run detection and deblending of peaks, as well as basic measurments such as
-    centroid.  The SDSS deblender is run in order to split footprints.
-
-    We must combine detection and deblending in the same function because the
-    schema gets modified in place, which means we must construct the deblend
-    task at the same time as the detect task
-
-    Parameters
-    ----------
-    rng: np.random.RandomState
-        Random number generator for noise replacer
-    thresh: float, optional
-        The detection threshold in units of the sky noise
-    config: dict, optional
-        The configuration dictionary to override the defaults with.
-
-    Returns
-    -------
-    sources, detexp
-        The sources and the detection exposure
-    """
-    if deblender is not None:
-        LOG.warning(
-            "'deblender' kwargs is not used and will be removed soon. "
-            "Specify the deblender via the config kwarg instead."
-        )
-
-    config_override = config if config is not None else {}
-    if thresh:
-        if 'detect' not in config_override:
-            config_override['detect'] = {}
-        config_override['detect']['thresholdValue'] = thresh
-
-    config = DetectAndDeblendConfig()
-    config.setDefaults()
-
-    if config_override.get('deblend', {}).pop('name', '') == "scarlet":
-        config.deblend.retarget(ScarletDeblendTask)
-
-    util.override_config(config, config_override)
-
-    config.freeze()
-    config.validate()
-    task = DetectAndDeblendTask(config=config)
-    if rng is not None:
-        task.rng = rng
-    return task
-
-
 def measure(
     mbexp,
     detexp,

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -297,52 +297,6 @@ class MetadetectTask(Task):
         return result
 
 
-def detect_deblend_and_measure(
-    mbexp,
-    config,
-    rng,
-    show=False,
-):
-    """
-    run detection, deblending and measurements.
-
-    Parameters
-    ----------
-    mbexp: lsst.afw.image.MultibandExposure
-        The metacal'ed exposures to process
-    config: dict, optional
-        Configuration for the fitter, metacal, psf, detect, Entries
-        in this dict override defaults; see lsst_configs.py
-    rng: np.random.RandomState
-        Random number generator
-    show: bool, optional
-        If set to True, show images during processing
-    """
-
-    config = DetectAndDeblendConfig()
-
-    if config_override.get('deblend', {}).pop('name', '') == "scarlet":
-        config.deblend.retarget(ScarletDeblendTask)
-
-    dbtask = DetectAndDeblendTask(config=config)
-    if rng is not None:
-        dbtask.rng = rng
-    sources, detexp, model_data = dbtask.run(mbexp=mbexp, show=show)
-
-    results = measure.measure(
-        mbexp=mbexp,
-        model_data=model_data,
-        meas_task=dbtask.meas,
-        detexp=detexp,
-        sources=sources,
-        config=config,
-        rng=rng,
-        show=show,
-    )
-
-    return results
-
-
 def add_mfrac(config, mfrac, res, exp):
     """
     calculate and add mfrac to the input result array

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -246,6 +246,7 @@ class MetadetectTask(Task):
 
         result = {}
         for shear_str, mcal_mbexp in mdict.items():
+            # This method needs to be refactored.
             res = detect_deblend_and_measure(
                 mbexp=mcal_mbexp,
                 config=config,
@@ -291,11 +292,14 @@ def detect_deblend_and_measure(
         If set to True, show images during processing
     """
 
-    dbtask = measure.get_detect_and_deblend_task(
-        rng=rng,
-        thresh=config['detect']['thresh'],
-        config=config,
-    )
+    config = DetectAndDeblendConfig()
+
+    if config_override.get('deblend', {}).pop('name', '') == "scarlet":
+        config.deblend.retarget(ScarletDeblendTask)
+
+    dbtask = DetectAndDeblendTask(config=config)
+    if rng is not None:
+        dbtask.rng = rng
     sources, detexp, model_data = dbtask.run(mbexp=mbexp, show=show)
 
     results = measure.measure(

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -267,10 +267,10 @@ class MetadetectTask(Task):
         for shear_str, mcal_mbexp in mdict.items():
             if rng is not None:
                 dbtask.rng = rng
-            sources, detexp, model_data = dbtask.run(mbexp=mbexp, show=show)
+            sources, detexp, model_data = dbtask.run(mbexp=mcal_mbexp, show=show)
 
             res = measure.measure(
-                mbexp=mbexp,
+                mbexp=mcal_mbexp,
                 model_data=model_data,
                 meas_task=dbtask.meas,
                 detexp=detexp,

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -89,7 +89,10 @@ def run_metadetect(
         If get_psf_stats=True then there is an extra entry 'psf_stats'
     """
 
-    config_override = config if config is not None else {}
+    config_override = deepcopy(DEFAULT_MDET_CONFIG)
+    if config:
+        config_override.update(config)
+
     config = MetadetectConfig()
     config.setDefaults()
 

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -165,6 +165,7 @@ class MetadetectConfig(Config):
             "sdss": "The SDSS style deblender",
             "scarlet": "The Scarlet deblender",
         },
+        deprecated="Deprecated and unused",
     )
 
     metacal = ConfigField[MetacalConfig](

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -293,7 +293,7 @@ def detect_deblend_and_measure(
     dbtask = measure.get_detect_and_deblend_task(
         rng=rng,
         thresh=config['detect']['thresh'],
-        deblender=config['deblender'],
+        config=config,
     )
     sources, detexp, model_data = dbtask.run(mbexp=mbexp, show=show)
 

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -19,6 +19,8 @@ from .. import procflags
 from .skysub import subtract_sky_mbexp
 
 from .defaults import (
+    DEFAULT_DEBLEND_SCARLET_CONFIG,
+    DEFAULT_DEBLEND_SDSS_CONFIG,
     DEFAULT_STAMP_SIZE,
     DEFAULT_SUBTRACT_SKY,
     DEFAULT_PGAUSS_FWHM,
@@ -34,6 +36,7 @@ def run_metadetect(
     mbexp,
     noise_mbexp,
     rng,
+    deblender='sdss',
     mfrac_mbexp=None,
     ormasks=None,
     config=None,
@@ -89,6 +92,16 @@ def run_metadetect(
     config_override = config if config is not None else {}
     config = MetadetectConfig()
     config.setDefaults()
+
+    if deblender == 'scarlet':
+        # Load the default scarlet config
+        config_override['deblend'] = deepcopy(DEFAULT_DEBLEND_SCARLET_CONFIG)
+        assert config_override['deblend'].pop('name') == 'scarlet'
+    elif deblender == 'sdss':
+        # SDSS deblender is the default, so no need to override
+        assert config_override['deblend'].pop('name') == 'sdss'
+    else:
+        raise ValueError(f"Unknown deblender: {deblender}")
 
     util.override_config(config, config_override)
 
@@ -158,6 +171,11 @@ class MetadetectConfig(Config):
         target=SourceDetectionTask,
     )
 
+    detect_and_deblend = ConfigurableField(
+        doc="Detection and Deblending config",
+        target=DetectAndDeblendTask,
+    )
+
     deblender = ChoiceField[str](
         doc="Type of deblender to run",
         default="sdss",
@@ -200,6 +218,7 @@ class MetadetectTask(Task):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.makeSubtask("detect")
+        self.makeSubtask("detect_and_deblend")
 
     def run(
         self,
@@ -244,11 +263,19 @@ class MetadetectTask(Task):
             types=metacal_types,
         )
 
+        dbtask = self.detect_and_deblend
         result = {}
         for shear_str, mcal_mbexp in mdict.items():
-            # This method needs to be refactored.
-            res = detect_deblend_and_measure(
-                mbexp=mcal_mbexp,
+            if rng is not None:
+                dbtask.rng = rng
+            sources, detexp, model_data = dbtask.run(mbexp=mbexp, show=show)
+
+            res = measure.measure(
+                mbexp=mbexp,
+                model_data=model_data,
+                meas_task=dbtask.meas,
+                detexp=detexp,
+                sources=sources,
                 config=config,
                 rng=rng,
                 show=show,

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -2,6 +2,9 @@ import logging
 import numpy as np
 import ngmix
 from ngmix.gexceptions import BootPSFFailure, GMixRangeError
+from copy import deepcopy
+from frozendict import frozendict
+
 from lsst.pex.config import (
     Config,
     ConfigField,
@@ -13,6 +16,7 @@ from lsst.pex.config import (
 )
 from lsst.pipe.base import Task
 from lsst.meas.algorithms import SourceDetectionTask
+from lsst.meas.extensions.scarlet import ScarletDeblendTask
 
 from .. import procflags
 
@@ -20,7 +24,7 @@ from .skysub import subtract_sky_mbexp
 
 from .defaults import (
     DEFAULT_DEBLEND_SCARLET_CONFIG,
-    DEFAULT_DEBLEND_SDSS_CONFIG,
+    DEFAULT_MDET_CONFIG,
     DEFAULT_STAMP_SIZE,
     DEFAULT_SUBTRACT_SKY,
     DEFAULT_PGAUSS_FWHM,
@@ -98,11 +102,14 @@ def run_metadetect(
 
     if deblender == 'scarlet':
         # Load the default scarlet config
-        config_override['deblend'] = deepcopy(DEFAULT_DEBLEND_SCARLET_CONFIG)
-        assert config_override['deblend'].pop('name') == 'scarlet'
+        config_override['detect_and_deblend']['deblend'] = deepcopy(
+            DEFAULT_DEBLEND_SCARLET_CONFIG
+        )
+        assert config_override['detect_and_deblend']['deblend'].pop('name') == 'scarlet'
+        config.detect_and_deblend.deblend.retarget(ScarletDeblendTask)
     elif deblender == 'sdss':
         # SDSS deblender is the default, so no need to override
-        assert config_override['deblend'].pop('name') == 'sdss'
+        assert config_override['detect_and_deblend']['deblend'].pop('name') == 'sdss'
     else:
         raise ValueError(f"Unknown deblender: {deblender}")
 
@@ -176,17 +183,7 @@ class MetadetectConfig(Config):
 
     detect_and_deblend = ConfigurableField(
         doc="Detection and Deblending config",
-        target=DetectAndDeblendTask,
-    )
-
-    deblender = ChoiceField[str](
-        doc="Type of deblender to run",
-        default="sdss",
-        allowed={
-            "sdss": "The SDSS style deblender",
-            "scarlet": "The Scarlet deblender",
-        },
-        deprecated="Deprecated and unused",
+        target=measure.DetectAndDeblendTask,
     )
 
     metacal = ConfigField[MetacalConfig](
@@ -234,8 +231,7 @@ class MetadetectTask(Task):
         show=False,
     ):
         # This is to support methods that are not yet refactored.
-        config = self.config.toDict()
-        config['detect']['thresh'] = self.detect.config.thresholdValue
+        config = frozendict(self.config.toDict())
 
         ormask = combine_ormasks(mbexp, ormasks)
         mfrac, wgts = get_mfrac_mbexp(mbexp=mbexp, mfrac_mbexp=mfrac_mbexp)

--- a/metadetect/lsst/model_subtractor.py
+++ b/metadetect/lsst/model_subtractor.py
@@ -10,12 +10,10 @@ from . import util
 
 import numpy as np
 import lsst.scarlet.lite as scl
-from lsst.afw.detection import HeavyFootprintF, makeHeavyFootprint
 from lsst.afw.detection.multiband import MultibandFootprint
-from lsst.afw.image import Mask, MaskedImage, MultibandImage
+from lsst.afw.image import Mask, MultibandImage
 from lsst.afw.geom import SpanSet
 from lsst.afw.detection import Footprint as afwFootprint
-from lsst.afw.image import Image as afwImage
 
 LOG = logging.getLogger('lsst_model_subtractor')
 
@@ -439,7 +437,10 @@ class ModelSubtractor(object):
                     footprint = source.getFootprint()
                     bbox = footprint.getBBox()
 
-                    heavy = scarletModelToHeavy(source=scl_source, blend=blend)
+                    heavy = scarletModelToMultibandFootprint(
+                        source=scl_source,
+                        blend=blend,
+                    )
 
                     for band in bands:
                         heavy[band].subtractFrom(self.mbexp[band].image[bbox])
@@ -449,22 +450,21 @@ class ModelSubtractor(object):
                     self.footprints[sid] = footprint
 
 
-def scarletModelToHeavy(
+def scarletModelToMultibandFootprint(
     source: scl.Source,
     blend: scl.Blend,
     useFlux=False,
-) -> HeavyFootprintF | MultibandFootprint:
+) -> MultibandFootprint:
     """
-    Convert a scarlet_lite model to a `HeavyFootprintF` or
-    `MultibandFootprint`.
+    Convert a scarlet_lite model to a `MultibandFootprint`.
 
-    This is a copy of the code from scarlet meas extension with
+    This is a modified copy of the code from scarlet meas extension with
     a bug fix for nbands in multi epoch
 
     Parameters
     ----------
     source:
-        The source to convert to a `HeavyFootprint`.
+        The source to convert to a `MultibandFootprint`.
     blend:
         The `Blend` object that contains information about
         the observation, PSF, etc, used to convolve the
@@ -476,7 +476,7 @@ def scarletModelToHeavy(
     Returns
     -------
     heavy:
-        The footprint (possibly multiband) containing the model for the source.
+        The multiband footprint containing the model for the source.
     """
     # We want to convolve the model with the observed PSF,
     # which means we need to grow the model box by the PSF to
@@ -510,24 +510,14 @@ def scarletModelToHeavy(
     valid = Mask(valid.astype(np.int32), xy0=xy0)
     spans = SpanSet.fromMask(valid)
 
-    # Create the MultibandHeavyFootprint and
+    # Create the MultibandFootprint and
     # add the location of the source to the peak catalog.
     foot = afwFootprint(spans)
     foot.addPeak(source.center[1], source.center[0], np.max(model.data))
-    if model.n_bands == 1:
-        image = afwImage(
-            array=model.data[0],
-            xy0=valid.getBBox().getMin(),
-            dtype=model.dtype,
-        )
-        maskedImage = MaskedImage(image, dtype=model.dtype)
-        heavy = makeHeavyFootprint(foot, maskedImage)
-    else:
-        # BUG fix:  was blend.bands
-        model = MultibandImage(
-            blend.observation.bands, model.data, valid.getBBox(),
-        )
-        heavy = MultibandFootprint.fromImages(
-            blend.observation.bands, model, footprint=foot
-        )
+    model = MultibandImage(
+        blend.observation.bands, model.data, valid.getBBox(),
+    )
+    heavy = MultibandFootprint.fromImages(
+        blend.observation.bands, model, footprint=foot
+    )
     return heavy

--- a/metadetect/lsst/photometry.py
+++ b/metadetect/lsst/photometry.py
@@ -8,6 +8,9 @@ from .metadetect import (
     fit_original_psfs_mbexp, get_mfrac_mbexp, combine_ormasks,
     add_ormask, add_original_psf, add_mfrac,
 )
+from lsst.meas.extensions.scarlet import ScarletDeblendTask
+from .defaults import DEFAULT_THRESH
+from . import util
 
 warnings.filterwarnings('ignore', category=FutureWarning)
 
@@ -66,7 +69,7 @@ def run_photometry(
         rng=rng,
     )
 
-    dbtask = measure.get_detect_and_deblend_task(
+    dbtask = get_detect_and_deblend_task(
         thresh=config['detect']['thresh'],
         rng=rng,
     )
@@ -94,3 +97,59 @@ def run_photometry(
         add_original_psf(psf_stats, res)
 
     return res
+
+
+def get_detect_and_deblend_task(
+    rng=None,
+    thresh=DEFAULT_THRESH,
+    deblender=None,
+    config=None,
+):
+    """
+    run detection and deblending of peaks, as well as basic measurments such as
+    centroid.  The SDSS deblender is run in order to split footprints.
+
+    We must combine detection and deblending in the same function because the
+    schema gets modified in place, which means we must construct the deblend
+    task at the same time as the detect task
+
+    Parameters
+    ----------
+    rng: np.random.RandomState
+        Random number generator for noise replacer
+    thresh: float, optional
+        The detection threshold in units of the sky noise
+    config: dict, optional
+        The configuration dictionary to override the defaults with.
+
+    Returns
+    -------
+    sources, detexp
+        The sources and the detection exposure
+    """
+    if deblender is not None:
+        LOG.warning(
+            "'deblender' kwargs is not used and will be removed soon. "
+            "Specify the deblender via the config kwarg instead."
+        )
+
+    config_override = config if config is not None else {}
+    if thresh:
+        if 'detect' not in config_override:
+            config_override['detect'] = {}
+        config_override['detect']['thresholdValue'] = thresh
+
+    config = measure.DetectAndDeblendConfig()
+    config.setDefaults()
+
+    if config_override.get('deblend', {}).pop('name', '') == "scarlet":
+        config.deblend.retarget(ScarletDeblendTask)
+
+    util.override_config(config, config_override)
+
+    config.freeze()
+    config.validate()
+    task = measure.DetectAndDeblendTask(config=config)
+    if rng is not None:
+        task.rng = rng
+    return task

--- a/metadetect/lsst/tests/regression_driver_v0_13_0.py
+++ b/metadetect/lsst/tests/regression_driver_v0_13_0.py
@@ -1,0 +1,92 @@
+"""
+Driver for the bit-identical regression test against tag 0.13.0, see
+test_regression_vs_0_13_0.py
+
+This script is run in subprocesses with PYTHONPATH pointing at different
+checkouts of metadetect, so it must only use API that exists both at tag
+0.13.0 and on the current branch.  In particular the deblender is selected
+through config['deblender'] at 0.13.0 but through the deblender keyword on
+the current branch; we detect which API is present from the signature.
+
+usage: python regression_driver_v0_13_0.py outfile deblender
+"""
+import inspect
+import sys
+
+import numpy as np
+
+SIM_SEED = 116
+MDET_SEED = 55
+BANDS = ['r', 'i']
+COADD_DIM = 251
+
+
+def make_lsst_sim(seed, mag=20, hlr=0.5):
+    import descwl_shear_sims
+
+    rng = np.random.RandomState(seed=seed)
+
+    galaxy_catalog = descwl_shear_sims.galaxies.FixedGalaxyCatalog(
+        rng=rng,
+        coadd_dim=COADD_DIM,
+        buff=20,
+        layout='grid',
+        mag=mag,
+        hlr=hlr,
+    )
+
+    psf = descwl_shear_sims.psfs.make_fixed_psf(psf_type='gauss')
+
+    return descwl_shear_sims.make_sim(
+        rng=rng,
+        galaxy_catalog=galaxy_catalog,
+        coadd_dim=COADD_DIM,
+        g1=0.02,
+        g2=0.00,
+        psf=psf,
+        bands=BANDS,
+    )
+
+
+def run(deblender):
+    from descwl_coadd.coadd_nowarp import make_coadd_nowarp
+    from metadetect.lsst.metadetect import run_metadetect
+    from metadetect.lsst import util
+
+    sim_data = make_lsst_sim(SIM_SEED)
+
+    rng = np.random.RandomState(seed=MDET_SEED)
+    coadd_data_list = [
+        make_coadd_nowarp(
+            exp=sim_data['band_data'][band][0],
+            psf_dims=sim_data['psf_dims'],
+            rng=rng,
+            remove_poisson=False,
+        )
+        for band in BANDS
+    ]
+    data = util.extract_multiband_coadd_data(coadd_data_list)
+
+    kwargs = {}
+    config = {}
+    if 'deblender' in inspect.signature(run_metadetect).parameters:
+        kwargs['deblender'] = deblender
+    else:
+        config['deblender'] = deblender
+
+    return run_metadetect(rng=rng, config=config, **kwargs, **data)
+
+
+def main(outfile, deblender):
+    import metadetect
+
+    res = run(deblender)
+
+    out = {key: res[key] for key in res}
+    out['__metadetect_file__'] = np.array(metadetect.__file__)
+    np.savez(outfile, **out)
+    print('wrote', outfile, 'using metadetect from', metadetect.__file__)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1], sys.argv[2])

--- a/metadetect/lsst/tests/test_lsst_conventions.py
+++ b/metadetect/lsst/tests/test_lsst_conventions.py
@@ -7,6 +7,7 @@ import numpy as np
 import logging
 from metadetect.lsst.configs import get_config
 import metadetect.lsst.measure as lsst_measure
+from metadetect.lsst.photometry import get_detect_and_deblend_task
 from metadetect.lsst import util
 
 logging.basicConfig(
@@ -96,7 +97,7 @@ def test_convention(ginput):
 
     data = do_coadding(rng=rng, sim_data=sim_data, nowarp=True)
 
-    dbtask = lsst_measure.get_detect_and_deblend_task(rng=rng)
+    dbtask = get_detect_and_deblend_task(rng=rng)
     sources, detexp, model_data = dbtask.run(mbexp=data['mbexp'])
 
     config = get_config()

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -536,11 +536,9 @@ def test_lsst_metadetect_deblender_grid(deblender):
     sim_data = make_lsst_sim(116, bands=bands)
     data = do_coadding(rng=rng, sim_data=sim_data, nowarp=True)
 
-    config = {
-        'deblender': deblender,
-    }
+    config = {}
 
-    res = run_metadetect(rng=rng, config=config, **data)
+    res = run_metadetect(rng=rng, deblender=deblender, config=config, **data)
 
     metacal_types = ['noshear', '1p', '1m']
 
@@ -578,11 +576,9 @@ def test_lsst_metadetect_deblender_random(deblender, show=False):
     if show:
         vis.show_image(data['mbexp']['i'].image.array)
 
-    config = {
-        'deblender': deblender,
-    }
+    config = {}
 
-    res = run_metadetect(rng=rng, config=config, **data)
+    res = run_metadetect(rng=rng, deblender=deblender, config=config, **data)
 
     if show:
         vis.show_image(data['mbexp']['i'].image.array, cat=res['noshear'])

--- a/metadetect/lsst/tests/test_lsst_model_subtractor.py
+++ b/metadetect/lsst/tests/test_lsst_model_subtractor.py
@@ -5,6 +5,10 @@ import pytest
 import time
 
 import logging
+from metadetect.lsst.defaults import (
+    DEFAULT_DEBLEND_SDSS_CONFIG,
+    DEFAULT_DEBLEND_SCARLET_CONFIG,
+)
 from metadetect.lsst.measure import get_detect_and_deblend_task
 from metadetect.lsst import util
 from metadetect.lsst import vis
@@ -92,7 +96,8 @@ def test_lsst_model_subtractor_smoke(seed=225, ntrial=1, show=False):
             vis.show_mbexp(mbexp)
 
         tm0 = time.time()
-        dbtask = get_detect_and_deblend_task(rng=rng, deblender='scarlet')
+        config_override = {'deblend': DEFAULT_DEBLEND_SCARLET_CONFIG}
+        dbtask = get_detect_and_deblend_task(rng=rng, config=config_override)
         sources, detecp, model_data = dbtask.run(
             mbexp=mbexp,
             show=show,
@@ -155,7 +160,8 @@ def test_lsst_mbobs_extractor_smoke(seed=225, show=False):
     if show:
         vis.show_mbexp(mbexp)
 
-    dbtask = get_detect_and_deblend_task(rng=rng, deblender='sdss')
+    config_override = {'deblend': DEFAULT_DEBLEND_SDSS_CONFIG}
+    dbtask = get_detect_and_deblend_task(rng=rng, config=config_override)
     sources, detecp, model_data = dbtask.run(
         mbexp=mbexp,
         show=show,

--- a/metadetect/lsst/tests/test_lsst_model_subtractor.py
+++ b/metadetect/lsst/tests/test_lsst_model_subtractor.py
@@ -9,7 +9,7 @@ from metadetect.lsst.defaults import (
     DEFAULT_DEBLEND_SDSS_CONFIG,
     DEFAULT_DEBLEND_SCARLET_CONFIG,
 )
-from metadetect.lsst.measure import get_detect_and_deblend_task
+from metadetect.lsst.photometry import get_detect_and_deblend_task
 from metadetect.lsst import util
 from metadetect.lsst import vis
 from metadetect.lsst.model_subtractor import ModelSubtractor

--- a/metadetect/lsst/tests/test_lsst_photometry.py
+++ b/metadetect/lsst/tests/test_lsst_photometry.py
@@ -121,8 +121,7 @@ def test_lsst_photometry_smoke(subtract_sky, nowarp):
 
 
 if __name__ == '__main__':
-    for mt in ['pgauss', 'ksigma']:
-        for nowarp in [True, False]:
-            test_lsst_photometry_smoke(
-                meas_type=mt, subtract_sky=False, nowarp=nowarp
-            )
+    for nowarp in [True, False]:
+        test_lsst_photometry_smoke(
+            subtract_sky=False, nowarp=nowarp
+        )

--- a/metadetect/lsst/tests/test_lsst_skysub.py
+++ b/metadetect/lsst/tests/test_lsst_skysub.py
@@ -5,7 +5,7 @@ import pytest
 import tqdm
 import logging
 import metadetect.lsst.skysub as lsst_skysub
-import metadetect.lsst.measure as lsst_measure
+from metadetect.lsst.photometry import get_detect_and_deblend_task
 
 logging.basicConfig(
     stream=sys.stdout,
@@ -266,7 +266,7 @@ def test_skysub_sim_wldeblend_gal(star_density, sky_n_sigma):
         else:
             # this one is for debugging; we do the iterations ourselves so we
             # can display the result
-            dbtask = lsst_measure.get_detect_and_deblend_task(thresh=5)
+            dbtask = get_detect_and_deblend_task(thresh=5)
             _ = dbtask.run(exp)
             if False:
                 show_mask(exp)

--- a/metadetect/lsst/tests/test_regression_vs_0_13_0.py
+++ b/metadetect/lsst/tests/test_regression_vs_0_13_0.py
@@ -1,0 +1,81 @@
+"""
+Check that this branch gives bit-identical results to tag 0.13.0
+
+A git worktree of the tag is created and regression_driver_v0_13_0.py is run
+in subprocesses, once with PYTHONPATH pointing at the worktree and once with
+it pointing at this checkout, in the same environment so the only variable is
+the metadetect code.  Requires the git history, so this is skipped unless
+METADETECT_REGRESSION_TEST=1 is set.
+"""
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+TAG = '0.13.0'
+DRIVER = os.path.join(
+    os.path.dirname(__file__), 'regression_driver_v0_13_0.py'
+)
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..', '..')
+)
+
+
+def run_driver(checkout, outfile, deblender):
+    # prepend so the checkout wins over any other metadetect on PYTHONPATH,
+    # e.g. from eups; the stack itself is also on PYTHONPATH so we must
+    # extend rather than replace
+    pythonpath = checkout + os.pathsep + os.environ.get('PYTHONPATH', '')
+    env = dict(os.environ, PYTHONPATH=pythonpath)
+    subprocess.run(
+        [sys.executable, DRIVER, outfile, deblender],
+        env=env, check=True, cwd=os.path.dirname(outfile),
+    )
+
+
+@pytest.mark.skipif(
+    os.environ.get('METADETECT_REGRESSION_TEST') != '1',
+    reason='set METADETECT_REGRESSION_TEST=1 to run',
+)
+@pytest.mark.parametrize('deblender', ['sdss', 'scarlet'])
+def test_bit_identical_vs_0_13_0(deblender, tmp_path):
+    worktree = str(tmp_path / f'metadetect-{TAG}')
+    subprocess.run(
+        ['git', '-C', REPO_ROOT, 'worktree', 'add', '--detach', worktree, TAG],
+        check=True,
+    )
+
+    try:
+        old_file = str(tmp_path / f'old-{deblender}.npz')
+        new_file = str(tmp_path / f'new-{deblender}.npz')
+
+        run_driver(worktree, old_file, deblender)
+        run_driver(REPO_ROOT, new_file, deblender)
+
+        with np.load(old_file) as old, np.load(new_file) as new:
+            # make sure each run imported the intended version
+            assert str(old['__metadetect_file__']).startswith(worktree)
+            assert str(new['__metadetect_file__']).startswith(REPO_ROOT)
+
+            old_keys = set(old.files) - {'__metadetect_file__'}
+            new_keys = set(new.files) - {'__metadetect_file__'}
+            assert old_keys == new_keys
+
+            for key in sorted(old_keys):
+                old_res, new_res = old[key], new[key]
+                assert old_res.dtype == new_res.dtype, key
+                assert old_res.shape == new_res.shape, key
+                assert old_res.tobytes() == new_res.tobytes(), key
+    finally:
+        subprocess.run(
+            ['git',
+             '-C',
+             REPO_ROOT,
+             'worktree',
+             'remove',
+             '--force',
+             worktree],
+            check=True,
+        )


### PR DESCRIPTION
This addresses some of my comments in #247 . The main change is instead of specifying a `deblender` argument that can either be `sdss` or `scarlet`, it instead passes a configuration dictionary, that encompasses any configuration overrides. This explicitly puts all the configuration in `defaults.py` instead of having it embedded somewhere in the code.