### PR TITLE
Switch filters to bands

### DIFF
--- a/metadetect/lsst/mbobs_extractor.py
+++ b/metadetect/lsst/mbobs_extractor.py
@@ -130,7 +130,7 @@ class MBObsExtractor(object):
             clip=clip,
         )
 
-        exposures = [self.mbexp[band][bbox] for band in self.filters]
+        exposures = [self.mbexp[band][bbox] for band in self.bands]
         return util.get_mbexp(exposures)
 
     def get_mbobs(

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -117,8 +117,7 @@ class MetacalConfig(Config):
         ],
     )
 
-    reconv_type = ChoiceField(
-        dtype=str,
+    reconv_type = ChoiceField[str](
         doc="Type of reconvolution kernel to use",
         default="fitgauss",
         allowed={

--- a/metadetect/lsst/model_subtractor.py
+++ b/metadetect/lsst/model_subtractor.py
@@ -75,7 +75,7 @@ class ModelSubtractor(object):
 
         self.sources = sources
 
-        self.bands = mbexp.filters
+        self.bands = mbexp.bands
 
         self._build_subtracted_image()
 

--- a/metadetect/lsst/util.py
+++ b/metadetect/lsst/util.py
@@ -402,8 +402,8 @@ def get_mbexp(exposures):
     """
     from lsst.afw.image import MultibandExposure
 
-    filters = [exp.getFilter().bandLabel for exp in exposures]
-    mbexp = MultibandExposure.fromExposures(filters, exposures)
+    bands = [exp.getFilter().bandLabel for exp in exposures]
+    mbexp = MultibandExposure.fromExposures(bands, exposures)
 
     for exp, sexp in zip(exposures, mbexp.singles):
         sexp.setFilter(exp.getFilter())


### PR DESCRIPTION
The `filters` property was already deprecated when these uses were added, and is slated for removal, potentially as early as this week.