### PR TITLE
BUG shear bands not used for averaging original PSF quantities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
       sub-package. This is now the default.
     - Fixed bug where psfrec original PSF quantities were calculatede
       over all bands rather than shear bands.
-    - Added 'perband_psf_stats' to result dict of MetadetectTask.run()
+    - Added abilityu to optionally add 'psf_stats' to
+      result dict of MetadetectTask.run()
 
 ## 0.12.0 - 2023-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.0 - 2025-12-02
+## 0.13.0 - 2025-12-02, 2026-05-08
 
 ### changed
 
@@ -9,6 +9,9 @@
     - keep track of problems with stamp images in separate stamp_flags field
     - support fitgauss method for getting reconvolution kernel in the lsst
       sub-package. This is now the default.
+    - Fixed bug where psfrec original PSF quantities were calculatede
+      over all bands rather than shear bands.
+    - Added 'perband_psf_stats' to result dict of MetadetectTask.run()
 
 ## 0.12.0 - 2023-04-03
 

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -353,16 +353,10 @@ def measure(
     pgauss_fitter = get_pgauss_fitter(config['pgauss'])
 
     nband = len(mbexp.bands)
-    shear_band_names = config["shear_bands"] or mbexp.bands
-    if not all([sb in mbexp.bands for sb in shear_band_names]):
-        raise RuntimeError(
-            "Not all requested bands for shear are available. "
-            f"Bands `{shear_band_names}` were requested but the only "
-            f"bands available are `{mbexp.bands}`."
-        )
-    shear_bands = [
-        i for i, band in enumerate(mbexp.bands) if band in shear_band_names
-    ]
+    shear_band_indices = util.extract_shear_band_indices(
+        mbexp=mbexp,
+        config=config,
+    )
     exp_bbox = mbexp.getBBox()
     wcs = mbexp.singles[0].getWcs()
     results = []
@@ -412,7 +406,7 @@ def measure(
             this_gauss_res = get_wavg_output_struct(
                 nband=nband,
                 model='gauss',
-                shear_bands=shear_bands,
+                shear_bands=shear_band_indices,
             )
             this_pgauss_res = get_wavg_output_struct(
                 nband=nband,
@@ -439,7 +433,7 @@ def measure(
                 bmask_flags=0,
                 psf_runner=psf_runner,
                 rng=rng,
-                shear_bands=shear_bands,
+                shear_bands=shear_band_indices,
             )
 
             this_pgauss_res = fit_mbobs_wavg(
@@ -582,6 +576,7 @@ def get_output_dtype():
         ('ra', 'f8'),
         ('dec', 'f8'),
         ('psfrec_flags', 'i4'),  # psfrec is the original psf
+        ('psfrec_navg', 'i2'),  # psfrec is the original psf
         ('psfrec_g', 'f8', 2),
         ('psfrec_T', 'f8'),
         # values from .mask of input exposures

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -71,8 +71,8 @@ def run_metadetect(
         Configuration for the fitter, metacal, psf, detect, Entries
         in this dict override defaults; see lsst_configs.py
     get_psf_stats: bool, optional
-        If set to True, also return the psf stats.  See the returned data of
-        fit_original_psfs_mbexp
+        If set to True, also return the psf stats as a 'psf_stats' entry
+        in the result dict.  See the returned data of fit_original_psfs_mbexp
     show: bool, optional
         if set to True images will be shown
 
@@ -83,8 +83,7 @@ def run_metadetect(
         if there was a problem doing the metacal steps; this only happens if
         the setting metacal_psf is set to 'fitgauss' and the fitting fails
 
-    If get_psf_stats=True the psf stats are also returned. See the
-    returned data of fit_original_psfs_mbexp
+        If get_psf_stats=True then there is an extra entry 'psf_stats'
     """
 
     config_override = config if config is not None else {}
@@ -264,9 +263,9 @@ class MetadetectTask(Task):
             result[shear_str] = res
 
         if get_psf_stats:
-            return result, psf_stats
-        else:
-            return result
+            result['psf_stats'] = psf_stats
+
+        return result
 
 
 def detect_deblend_and_measure(

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -37,6 +37,7 @@ def run_metadetect(
     mfrac_mbexp=None,
     ormasks=None,
     config=None,
+    get_psf_stats=False,
     show=False,
 ):
     """
@@ -69,15 +70,21 @@ def run_metadetect(
     config: dict, optional
         Configuration for the fitter, metacal, psf, detect, Entries
         in this dict override defaults; see lsst_configs.py
+    get_psf_stats: bool, optional
+        If set to True, also return the psf stats.  See the returned data of
+        fit_original_psfs_mbexp
     show: bool, optional
         if set to True images will be shown
 
     Returns
     -------
-    result dict
-        This is keyed by shear string 'noshear', '1p', ... or None if there was
-        a problem doing the metacal steps; this only happens if the setting
-        metacal_psf is set to 'fitgauss' and the fitting fails
+    result dict:
+        The result dict is keyed by shear string 'noshear', '1p', ... or None
+        if there was a problem doing the metacal steps; this only happens if
+        the setting metacal_psf is set to 'fitgauss' and the fitting fails
+
+    If get_psf_stats=True the psf stats are also returned. See the
+    returned data of fit_original_psfs_mbexp
     """
 
     config_override = config if config is not None else {}
@@ -89,15 +96,15 @@ def run_metadetect(
     config.freeze()
     config.validate()
     task = MetadetectTask(config=config)
-    result = task.run(
+    return task.run(
         mbexp,
         noise_mbexp,
         rng,
         mfrac_mbexp,
         ormasks,
         show=show,
+        get_psf_stats=get_psf_stats,
     )
-    return result
 
 
 class PGaussConfig(Config):
@@ -201,6 +208,7 @@ class MetadetectTask(Task):
         rng,
         mfrac_mbexp=None,
         ormasks=None,
+        get_psf_stats=False,
         show=False,
     ):
         # This is to support methods that are not yet refactored.
@@ -255,8 +263,10 @@ class MetadetectTask(Task):
 
             result[shear_str] = res
 
-        result['perband_psf_stats'] = psf_stats['perband']
-        return result
+        if get_psf_stats:
+            return result, psf_stats
+        else:
+            return result
 
 
 def detect_deblend_and_measure(

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -217,6 +217,7 @@ class MetadetectTask(Task):
 
         psf_stats = fit_original_psfs_mbexp(
             mbexp=mbexp,
+            config=config,
             wgts=wgts,
             rng=rng,
         )
@@ -254,6 +255,7 @@ class MetadetectTask(Task):
 
             result[shear_str] = res
 
+        result['perband_psf_stats'] = psf_stats['perband']
         return result
 
 
@@ -437,6 +439,7 @@ def add_original_psf(psf_stats, res):
     copy in psf results
     """
     res['psfrec_flags'][:] = psf_stats['flags']
+    res['psfrec_navg'][:] = psf_stats['navg']
     res['psfrec_g'][:, 0] = psf_stats['g1']
     res['psfrec_g'][:, 1] = psf_stats['g2']
     res['psfrec_T'][:] = psf_stats['T']
@@ -501,19 +504,46 @@ def get_mfrac_mbexp(mbexp, mfrac_mbexp):
     return mfrac, wgts
 
 
-def fit_original_psfs_mbexp(mbexp, rng, wgts):
+def fit_original_psfs_mbexp(mbexp, rng, wgts, config):
     """
-    fit the original psfs at the center of the image and get the mean g1,g2,T
-    across all bands
+    fit the original psfs at the center of the image.
+
+    also get the mean g1,g2,T across shear bands
 
     This can fail and flags will be set, but we proceed
+
+    Parameters
+    ----------
+    mbexp: MutiBandExposure
+        The image data
+    rng: np.random.RandomState
+        The numpy random state
+    wgts: sequence
+        Sequence of weights, one per image
+    config: dict like
+        Should have the metadetect config into
+
+    Returns
+    -------
+    dict with entries
+        flags: Flags for processing
+        navg: Number of images averaged, should be same size as shear bands
+        e1: mean e1 (distortion style)
+        e2: mean e2 (distortion style)
+        g1: mean g1 (reduced shear style)
+        g2: mean g2 (reduced shear style)
+        T: Mean trace of the covariance matrix
+        perband: array with results for each band separately. this
+            includes non shear bands.
     """
+
+    shear_band_indices = util.extract_shear_band_indices(
+        mbexp=mbexp,
+        config=config,
+    )
 
     nband = len(mbexp)
     assert len(wgts) == nband
-    wsum = sum(wgts)
-    if wsum <= 0:
-        raise ValueError(f'got sum(wgts) = {wsum}')
 
     fitter = ngmix.admom.AdmomFitter(rng=rng)
     guesser = ngmix.guessers.GMixPSFGuesser(
@@ -524,15 +554,26 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
     runner = ngmix.runners.PSFRunner(fitter=fitter, guesser=guesser, ntry=4)
 
     perband = np.zeros(
-        nband, dtype=[('e1', 'f8'), ('e2', 'f8'), ('T', 'f8')]
+        nband,
+        dtype=[
+            ('e1', 'f8'),
+            ('e2', 'f8'),
+            ('wgt', 'f8'),
+            ('T', 'f8'),
+            ('is_shear_band', bool),
+        ]
     )
 
     try:
+        # these are only summed over shear_bands
+        navg = 0
+        wsum = 0.0
         e1sum = 0.0
         e2sum = 0.0
         Tsum = 0.0
 
         for iband, exp, wgt in zip(range(nband), mbexp, wgts):
+
             cen, _ = util.get_integer_center(
                 wcs=exp.getWcs(),
                 bbox=exp.getBBox(),
@@ -557,13 +598,21 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
             e1, e2 = res['e']
             T = res['T']
 
-            e1sum += e1 * wgt
-            e2sum += e2 * wgt
-            Tsum += T * wgt
-
             perband['e1'][iband] = e1
             perband['e2'][iband] = e2
             perband['T'][iband] = T
+            perband['wgt'][iband] = wgt
+
+            if iband in shear_band_indices:
+                perband['is_shear_band'][iband] = True
+                navg += 1
+                wsum += wgt
+                e1sum += e1 * wgt
+                e2sum += e2 * wgt
+                Tsum += T * wgt
+
+        if wsum <= 0:
+            raise ValueError(f'got sum(wgts) = {wsum}')
 
         e1 = e1sum / wsum
         e2 = e2sum / wsum
@@ -581,8 +630,13 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
 
         perband = None
 
+    assert navg == len(shear_band_indices), (
+        f'summed {navg} but expected {len(shear_band_indices)}'
+    )
+
     return {
         'flags': flags,
+        'navg': navg,
         'e1': e1,
         'e2': e2,
         'g1': g1,

--- a/metadetect/lsst/photometry.py
+++ b/metadetect/lsst/photometry.py
@@ -60,6 +60,7 @@ def run_photometry(
         subtract_sky_mbexp(mbexp=mbexp, thresh=config['detect']['thresh'])
 
     psf_stats = fit_original_psfs_mbexp(
+        config=config,
         mbexp=mbexp,
         wgts=wgts,
         rng=rng,

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -240,7 +240,9 @@ def test_lsst_metadetect_shear_bands():
     metacal_types = ['noshear', '1p', '1m']
 
     detected = afw_image.Mask.getPlaneBitMask('DETECTED')
-    res = run_metadetect(rng=rng, config=config, **data)
+    res, psf_stats = run_metadetect(
+        rng=rng, config=config, get_psf_stats=True, **data,
+    )
 
     # we remove the DETECTED bit
     assert np.all(res['noshear']['bmask'] & detected == 0)
@@ -265,7 +267,8 @@ def test_lsst_metadetect_shear_bands():
             assert np.all(res[shear]["mfrac"] == 0)
             assert res[shear][flux_name].shape == (25, nband)
 
-    perband = res['perband_psf_stats']
+    perband = psf_stats['perband']
+
     assert perband.size == len(bands)
     shear_band_indices, = np.where(perband['is_shear_band'])
     assert shear_band_indices.size == len(shear_bands)
@@ -389,17 +392,17 @@ def test_lsst_zero_weights(show=False):
             data['mbexp']['i'].variance.array[50:100, 50:100] = np.inf
             data['noise_mbexp']['i'].variance.array[50:100, 50:100] = np.inf
 
-            if show:
-                import matplotlib.pyplot as mplt
-                fig, axs = mplt.subplots(ncols=2)
-                axs[0].imshow(data['mbexp']['i'].image.array)
-                axs[1].imshow(data['mbexp']['i'].variance.array)
-                mplt.show()
+        if show:
+            import matplotlib.pyplot as mplt
+            fig, axs = mplt.subplots(ncols=2)
+            axs[0].imshow(data['mbexp']['i'].image.array)
+            axs[1].imshow(data['mbexp']['i'].variance.array)
+            mplt.show()
 
         resdict = run_metadetect(rng=rng, config=None, **data)
 
         if do_zero:
-            for shear_type, tres in resdict.items():
+            for key, tres in resdict.items():
                 w, = np.where(
                     tres['stamp_flags'] & procflags.ZERO_WEIGHTS != 0
                 )
@@ -410,7 +413,9 @@ def test_lsst_zero_weights(show=False):
         else:
             for shear_type, tres in resdict.items():
                 # 5x5 grid
-                assert tres.size == 25
+                assert tres.size == 25, (
+                    f'checking {shear_type} for size 25'
+                )
 
         nobj.append(resdict['noshear'].size)
 
@@ -605,5 +610,6 @@ def test_lsst_metadetect_deblender_random(deblender, show=False):
 
 if __name__ == '__main__':
     # test_lsst_metadetect_deblender_random('sdss', show=True)
-    test_lsst_metadetect_reconv_size()
+    # test_lsst_metadetect_reconv_size()
     # test_lsst_metadetect_deblender_random('scarlet', show=True)
+    test_lsst_zero_weights(show=True)

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -240,9 +240,10 @@ def test_lsst_metadetect_shear_bands():
     metacal_types = ['noshear', '1p', '1m']
 
     detected = afw_image.Mask.getPlaneBitMask('DETECTED')
-    res, psf_stats = run_metadetect(
+    res = run_metadetect(
         rng=rng, config=config, get_psf_stats=True, **data,
     )
+    psf_stats = res.pop('psf_stats')
 
     # we remove the DETECTED bit
     assert np.all(res['noshear']['bmask'] & detected == 0)

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -42,23 +42,32 @@ def make_lsst_sim(
         hlr=hlr,
     )
 
-    if psf_type == 'ps':
-        psf = descwl_shear_sims.psfs.make_ps_psf(
-            rng=rng,
-            dim=300,
-        )
-    else:
-        psf = descwl_shear_sims.psfs.make_fixed_psf(psf_type=psf_type)
+    # This way we get different PSFs per band for PS PSF
+    sim_data = {'band_data': {}}
+    for band in bands:
+        if psf_type == 'ps':
+            psf = descwl_shear_sims.psfs.make_ps_psf(
+                rng=rng,
+                dim=300,
+            )
+        else:
+            psf = descwl_shear_sims.psfs.make_fixed_psf(psf_type=psf_type)
 
-    sim_data = descwl_shear_sims.make_sim(
-        rng=rng,
-        galaxy_catalog=galaxy_catalog,
-        coadd_dim=coadd_dim,
-        g1=0.02,
-        g2=0.00,
-        psf=psf,
-        bands=bands,
-    )
+        tsim_data = descwl_shear_sims.make_sim(
+            rng=rng,
+            galaxy_catalog=galaxy_catalog,
+            coadd_dim=coadd_dim,
+            g1=0.02,
+            g2=0.00,
+            psf=psf,
+            bands=bands,
+        )
+
+        for key in tsim_data:
+            if key == 'band_data':
+                sim_data['band_data'][band] = tsim_data['band_data'][band]
+            else:
+                sim_data[key] = tsim_data[key]
     return sim_data
 
 
@@ -221,11 +230,13 @@ def test_lsst_metadetect_shear_bands():
     rng = np.random.RandomState(seed=116)
 
     bands = ['g', 'r', 'i', 'z']
+    shear_bands = ["r", "z"]
+
     nband = len(bands)
-    sim_data = make_lsst_sim(116, bands=bands)
+    sim_data = make_lsst_sim(116, bands=bands, psf_type='ps')
     data = do_coadding(rng=rng, sim_data=sim_data, nowarp=True)
 
-    config = {"shear_bands": ["r", "z"]}
+    config = {"shear_bands": shear_bands}
     metacal_types = ['noshear', '1p', '1m']
 
     detected = afw_image.Mask.getPlaneBitMask('DETECTED')
@@ -254,15 +265,45 @@ def test_lsst_metadetect_shear_bands():
             assert np.all(res[shear]["mfrac"] == 0)
             assert res[shear][flux_name].shape == (25, nband)
 
+    perband = res['perband_psf_stats']
+    assert perband.size == len(bands)
+    shear_band_indices, = np.where(perband['is_shear_band'])
+    assert shear_band_indices.size == len(shear_bands)
+
+    print(perband['e1'])
+
+    wsum = perband['wgt'][shear_band_indices].sum()
+    e1sum = perband['e1'][shear_band_indices].sum()
+    e2sum = perband['e2'][shear_band_indices].sum()
+    Tsum = perband['T'][shear_band_indices].sum()
+    e1 = e1sum / wsum
+    e2 = e2sum / wsum
+    g1, g2 = ngmix.shape.e1e2_to_g1g2(e1, e2)
+    T = Tsum / wsum
+
     for shear in metacal_types:
         assert np.all(res[shear]["shear_bands"] == np.array([["13"]]))
+
         # g and i band should be all NaNs for gauss
         assert np.all(np.isnan(res[shear]["gauss_band_flux"][:, 0]))
         assert np.all(np.isnan(res[shear]["gauss_band_flux"][:, 2]))
+
         # rest should be finite
         assert np.all(np.isfinite(res[shear]["gauss_band_flux"][:, 1]))
         assert np.all(np.isfinite(res[shear]["gauss_band_flux"][:, 3]))
         assert np.all(np.isfinite(res[shear]["pgauss_band_flux"]))
+
+        assert np.all(res[shear]['psfrec_navg'] == len(shear_bands))
+
+        np.testing.assert_allclose(
+            res[shear]['psfrec_g'][:, 0], g1,
+        )
+        np.testing.assert_allclose(
+            res[shear]['psfrec_g'][:, 1], g2,
+        )
+        np.testing.assert_allclose(
+            res[shear]['psfrec_T'], T,
+        )
 
 
 def test_lsst_metadetect_pgauss():

--- a/metadetect/lsst/util.py
+++ b/metadetect/lsst/util.py
@@ -1299,3 +1299,36 @@ class MissingDataError(Exception):
 
     def __str__(self):
         return repr(self.value)
+
+
+def extract_shear_band_indices(mbexp, config):
+    """
+    Extract the indices requested shear bands, ensuring that each requested
+    band is available
+
+    Parameters
+    ----------
+    mbexp: MultiBandsExposure
+        The image data.  Must have .bands attribute
+    config: dict like
+        Must have entry 'shear_bands' holding band names
+
+    Returns
+    -------
+    List of band indices into the bands of mbexp
+    """
+    shear_band_names = config["shear_bands"] or mbexp.bands
+
+    if not all([sb in mbexp.bands for sb in shear_band_names]):
+        raise RuntimeError(
+            "Not all requested bands for shear are available. "
+            f"Bands `{shear_band_names}` were requested but the only "
+            f"bands available are `{mbexp.bands}`."
+        )
+
+    shear_band_indices = [
+        i for i, band in enumerate(mbexp.bands)
+        if band in shear_band_names
+    ]
+
+    return shear_band_indices


### PR DESCRIPTION
We now send shear bands to fit_original_psfs_mbexp We keep track in the perband structure of what was averaged

this perband stats structure is returned by the task as a dict entry

edit:  Adding the 'psf_stats' entry is optional with `get_psf_stats=True`