### PR TITLE
Perband psf stats

### DIFF
--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -207,6 +207,14 @@ class MetadetectTask(Task):
         config = self.config.toDict()
         config['detect']['thresh'] = self.detect.config.thresholdValue
 
+        shear_bands = config['shear_bands'] or mbexp.bands
+        if not all(band in mbexp.bands for band in shear_bands):
+            raise RuntimeError(
+                "Not all requested bands for shear are available. "
+                f"Bands `{shear_bands}` were requested but the only "
+                f"bands available are `{mbexp.bands}`."
+            )
+
         ormask = combine_ormasks(mbexp, ormasks)
         mfrac, wgts = get_mfrac_mbexp(mbexp=mbexp, mfrac_mbexp=mfrac_mbexp)
 
@@ -219,16 +227,19 @@ class MetadetectTask(Task):
                 mbexp=mbexp, thresh=self.config.detect.thresholdValue
             )
 
-        psf_stats = fit_original_psfs_mbexp(
+        psf_stats_perband = fit_original_psfs_mbexp(
             mbexp=mbexp,
-            wgts=wgts,
             rng=rng,
+        )
+        psf_stats = average_psf_stats(
+            psf_stats=psf_stats_perband,
+            wgts=wgts,
         )
 
         metacal_types = config['metacal'].get('types', None)
 
         if config['metacal']['reconv_type'] == 'fitgauss':
-            perband_psf_stats = psf_stats['perband']
+            perband_psf_stats = psf_stats_perband
         else:
             perband_psf_stats = None
 
@@ -257,6 +268,15 @@ class MetadetectTask(Task):
                 add_original_psf(psf_stats, res)
 
             result[shear_str] = res
+
+        # For additional information needed only for unit tests, include them
+        # under a catch-all key called '_diagnostics'. The calling code must
+        # not rely on this key being present or having the same structure.
+        result['_diagnostics'] = {
+            'psf_stats_perband': psf_stats_perband,
+            'weight_perband': {band: wgt for band, wgt in zip(mbexp.bands, wgts)},
+            'psf_stats_average': psf_stats,
+        }
 
         return result
 
@@ -505,19 +525,13 @@ def get_mfrac_mbexp(mbexp, mfrac_mbexp):
     return mfrac, wgts
 
 
-def fit_original_psfs_mbexp(mbexp, rng, wgts):
+def fit_original_psfs_mbexp(mbexp, rng):
     """
-    fit the original psfs at the center of the image and get the mean g1,g2,T
-    across all bands
+    fit the original psfs at the center of the image for each band
 
-    This can fail and flags will be set, but we proceed
+    Individual band fits can fail and flags will be set for that band, but
+    successful band fits are preserved.
     """
-
-    nband = len(mbexp)
-    assert len(wgts) == nband
-    wsum = sum(wgts)
-    if wsum <= 0:
-        raise ValueError(f'got sum(wgts) = {wsum}')
 
     fitter = ngmix.admom.AdmomFitter(rng=rng)
     guesser = ngmix.guessers.GMixPSFGuesser(
@@ -527,16 +541,19 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
     )
     runner = ngmix.runners.PSFRunner(fitter=fitter, guesser=guesser, ntry=4)
 
+    nband = len(mbexp.bands)
     perband = np.zeros(
-        nband, dtype=[('e1', 'f8'), ('e2', 'f8'), ('T', 'f8')]
+        nband, dtype=[
+            ('band', 'U1'),
+            ('e1', 'f8'),
+            ('e2', 'f8'),
+            ('T', 'f8'),
+            ('flags', 'i4'),
+        ]
     )
 
-    try:
-        e1sum = 0.0
-        e2sum = 0.0
-        Tsum = 0.0
-
-        for iband, exp, wgt in zip(range(nband), mbexp, wgts):
+    for iband, (band, exp) in enumerate(zip(mbexp.bands, mbexp)):
+        try:
             cen, _ = util.get_integer_center(
                 wcs=exp.getWcs(),
                 bbox=exp.getBBox(),
@@ -560,37 +577,87 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
 
             e1, e2 = res['e']
             T = res['T']
+            flags = 0
 
-            e1sum += e1 * wgt
-            e2sum += e2 * wgt
-            Tsum += T * wgt
+        except BootPSFFailure:
+            flags = procflags.PSF_FAILURE
+            e1 = -9999.0
+            e2 = -9999.0
+            T = -9999.0
 
-            perband['e1'][iband] = e1
-            perband['e2'][iband] = e2
-            perband['T'][iband] = T
+        perband['band'][iband] = band
+        perband['e1'][iband] = e1
+        perband['e2'][iband] = e2
+        perband['T'][iband] = T
+        perband['flags'][iband] = flags
 
-        e1 = e1sum / wsum
-        e2 = e2sum / wsum
-        T = Tsum / wsum
+    return perband
 
-        flags = 0
 
-        g1, g2 = ngmix.shape.e1e2_to_g1g2(e1=e1, e2=e2)
+def average_psf_stats(psf_stats, wgts):
+    """
+    Compute the weighted verage of psf stats over bands.
 
-    except (BootPSFFailure, GMixRangeError):
+    Parameters
+    ----------
+    psf_stats: numpy structured array
+        Per-band PSF stats as returned by fit_original_psfs_mbexp.
+        Array has fields: e1, e2, T, flags
+    wgts: list
+        Per-band weights, indexed by band position (same order as psf_stats).
+
+    Returns
+    -------
+    dict
+        Averaged psf stats with fields flags, e1, e2, g1, g2, and T.
+
+    Notes
+    -----
+    The g1 and g2 values are computed from the average e1 and e2 values.
+    They are not averaged g1 and g2 values over bands.
+    """
+
+    if len(wgts) != len(psf_stats):
+        raise ValueError(
+            f'len(wgts) = {len(wgts)} != len(psf_stats) = {len(psf_stats)}'
+        )
+
+    if any(wgt < 0 for wgt in wgts):
+        raise ValueError(f'got negative weight: {wgts}')
+
+    # Check for any failures
+    flags = 0
+    for iband in range(len(psf_stats)):
+        if wgts[iband] > 0:
+            flags |= psf_stats['flags'][iband]
+
+    if flags != 0:
+        return {
+            'flags': flags,
+            'e1': -9999.0,
+            'e2': -9999.0,
+            'g1': -9999.0,
+            'g2': -9999.0,
+            'T': -9999.0,
+        }
+
+    average_psf_stats = {'flags': 0}
+    for key in ('e1', 'e2', 'T'):
+        average_psf_stats[key] = sum(
+            psf_stats[key][iband] * wgts[iband] for iband in range(len(psf_stats))
+        ) / sum(wgts)
+
+    try:
+        g1, g2 = ngmix.shape.e1e2_to_g1g2(
+            e1=average_psf_stats['e1'],
+            e2=average_psf_stats['e2'],
+        )
+    except GMixRangeError:
         flags = procflags.PSF_FAILURE
-        e1 = -9999.0
-        e2 = -9999.0
-        T = -9999.0
+        g1 = -9999.0
+        g2 = -9999.0
 
-        perband = None
+    average_psf_stats['g1'] = g1
+    average_psf_stats['g2'] = g2
 
-    return {
-        'flags': flags,
-        'e1': e1,
-        'e2': e2,
-        'g1': g1,
-        'g2': g2,
-        'T': T,
-        'perband': perband,
-    }
+    return average_psf_stats

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -210,6 +210,10 @@ class MetadetectTask(Task):
         ormask = combine_ormasks(mbexp, ormasks)
         mfrac, wgts = get_mfrac_mbexp(mbexp=mbexp, mfrac_mbexp=mfrac_mbexp)
 
+        for i, band in enumerate(mbexp.bands):
+            if band not in shear_bands:
+                wgts[i] = 0
+
         if self.config.subtract_sky:
             subtract_sky_mbexp(
                 mbexp=mbexp, thresh=self.config.detect.thresholdValue

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -227,11 +227,11 @@ class MetadetectTask(Task):
                 mbexp=mbexp, thresh=self.config.detect.thresholdValue
             )
 
-        psf_stats_perband = fit_original_psfs_mbexp(
+        psf_stats_perband = _fit_original_psfs_mbexp(
             mbexp=mbexp,
             rng=rng,
         )
-        psf_stats = average_psf_stats(
+        psf_stats = _average_psf_stats(
             psf_stats=psf_stats_perband,
             wgts=wgts,
         )
@@ -525,7 +525,7 @@ def get_mfrac_mbexp(mbexp, mfrac_mbexp):
     return mfrac, wgts
 
 
-def fit_original_psfs_mbexp(mbexp, rng):
+def _fit_original_psfs_mbexp(mbexp, rng):
     """
     fit the original psfs at the center of the image for each band
 
@@ -594,14 +594,14 @@ def fit_original_psfs_mbexp(mbexp, rng):
     return perband
 
 
-def average_psf_stats(psf_stats, wgts):
+def _average_psf_stats(psf_stats, wgts):
     """
     Compute the weighted verage of psf stats over bands.
 
     Parameters
     ----------
     psf_stats: numpy structured array
-        Per-band PSF stats as returned by fit_original_psfs_mbexp.
+        Per-band PSF stats as returned by _fit_original_psfs_mbexp.
         Array has fields: e1, e2, T, flags
     wgts: list
         Per-band weights, indexed by band position (same order as psf_stats).

--- a/metadetect/lsst/photometry.py
+++ b/metadetect/lsst/photometry.py
@@ -56,6 +56,10 @@ def run_photometry(
     ormask = combine_ormasks(mbexp, ormasks)
     mfrac, wgts = get_mfrac_mbexp(mbexp, mfrac_mbexp)
 
+    for i, band in enumerate(mbexp.bands):
+        if band not in shear_bands:
+            wgts[i] = 0
+
     if config['subtract_sky']:
         subtract_sky_mbexp(mbexp=mbexp, thresh=config['detect']['thresh'])
 

--- a/metadetect/lsst/photometry.py
+++ b/metadetect/lsst/photometry.py
@@ -5,8 +5,8 @@ from .skysub import subtract_sky_mbexp
 from .configs import get_config
 from . import measure
 from .metadetect import (
-    fit_original_psfs_mbexp, get_mfrac_mbexp, combine_ormasks,
-    add_ormask, add_original_psf, add_mfrac, average_psf_stats,
+    _fit_original_psfs_mbexp, get_mfrac_mbexp, combine_ormasks,
+    add_ormask, add_original_psf, add_mfrac, _average_psf_stats,
 )
 
 warnings.filterwarnings('ignore', category=FutureWarning)
@@ -71,11 +71,11 @@ def run_photometry(
     if config['subtract_sky']:
         subtract_sky_mbexp(mbexp=mbexp, thresh=config['detect']['thresh'])
 
-    psf_stats_perband = fit_original_psfs_mbexp(
+    psf_stats_perband = _fit_original_psfs_mbexp(
         mbexp=mbexp,
         rng=rng,
     )
-    psf_stats = average_psf_stats(
+    psf_stats = _average_psf_stats(
         psf_stats=psf_stats_perband,
         wgts=wgts,
     )

--- a/metadetect/lsst/photometry.py
+++ b/metadetect/lsst/photometry.py
@@ -6,7 +6,7 @@ from .configs import get_config
 from . import measure
 from .metadetect import (
     fit_original_psfs_mbexp, get_mfrac_mbexp, combine_ormasks,
-    add_ormask, add_original_psf, add_mfrac,
+    add_ormask, add_original_psf, add_mfrac, average_psf_stats,
 )
 
 warnings.filterwarnings('ignore', category=FutureWarning)
@@ -53,6 +53,14 @@ def run_photometry(
 
     config = get_config(config)
 
+    shear_bands = config['shear_bands'] or mbexp.bands
+    if not all(band in mbexp.bands for band in shear_bands):
+        raise RuntimeError(
+            "Not all requested bands for shear are available. "
+            f"Bands `{shear_bands}` were requested but the only "
+            f"bands available are `{mbexp.bands}`."
+        )
+
     ormask = combine_ormasks(mbexp, ormasks)
     mfrac, wgts = get_mfrac_mbexp(mbexp, mfrac_mbexp)
 
@@ -63,10 +71,13 @@ def run_photometry(
     if config['subtract_sky']:
         subtract_sky_mbexp(mbexp=mbexp, thresh=config['detect']['thresh'])
 
-    psf_stats = fit_original_psfs_mbexp(
+    psf_stats_perband = fit_original_psfs_mbexp(
         mbexp=mbexp,
-        wgts=wgts,
         rng=rng,
+    )
+    psf_stats = average_psf_stats(
+        psf_stats=psf_stats_perband,
+        wgts=wgts,
     )
 
     dbtask = measure.get_detect_and_deblend_task(

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -356,6 +356,7 @@ def test_lsst_zero_weights(show=False):
                 mplt.show()
 
         resdict = run_metadetect(rng=rng, config=None, **data)
+        del resdict['_diagnostics']
 
         if do_zero:
             for shear_type, tres in resdict.items():
@@ -395,6 +396,7 @@ def test_lsst_masked_as_bright(show=False):
             data['noise_mbexp']['i'].mask.array[50:100, 50:100] |= bright
 
         resdict = run_metadetect(rng=rng, config=None, **data)
+        del resdict['_diagnostics']
 
         if show:
             import matplotlib.pyplot as mplt

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -42,23 +42,31 @@ def make_lsst_sim(
         hlr=hlr,
     )
 
-    if psf_type == 'ps':
-        psf = descwl_shear_sims.psfs.make_ps_psf(
-            rng=rng,
-            dim=300,
-        )
-    else:
-        psf = descwl_shear_sims.psfs.make_fixed_psf(psf_type=psf_type)
+    # This way we get different PSFs per band for PS PSF
+    sim_data = {'band_data': {}}
+    for band in bands:
+        if psf_type == 'ps':
+            psf = descwl_shear_sims.psfs.make_ps_psf(
+                rng=rng,
+                dim=300,
+            )
+        else:
+            psf = descwl_shear_sims.psfs.make_fixed_psf(psf_type=psf_type)
 
-    sim_data = descwl_shear_sims.make_sim(
-        rng=rng,
-        galaxy_catalog=galaxy_catalog,
-        coadd_dim=coadd_dim,
-        g1=0.02,
-        g2=0.00,
-        psf=psf,
-        bands=bands,
-    )
+        tsim_data = descwl_shear_sims.make_sim(
+            rng=rng,
+            galaxy_catalog=galaxy_catalog,
+            coadd_dim=coadd_dim,
+            g1=0.02,
+            g2=0.00,
+            psf=psf,
+            bands=bands,
+        )
+        for key in tsim_data:
+            if key == 'band_data':
+                sim_data['band_data'][band] = tsim_data['band_data'][band]
+            else:
+                sim_data[key] = tsim_data[key]
     return sim_data
 
 
@@ -221,15 +229,18 @@ def test_lsst_metadetect_shear_bands():
     rng = np.random.RandomState(seed=116)
 
     bands = ['g', 'r', 'i', 'z']
+    shear_bands = ['r', 'z']
+
     nband = len(bands)
-    sim_data = make_lsst_sim(116, bands=bands)
+    sim_data = make_lsst_sim(116, bands=bands, psf_type='ps')
     data = do_coadding(rng=rng, sim_data=sim_data, nowarp=True)
 
-    config = {"shear_bands": ["r", "z"]}
+    config = {"shear_bands": shear_bands}
     metacal_types = ['noshear', '1p', '1m']
 
     detected = afw_image.Mask.getPlaneBitMask('DETECTED')
     res = run_metadetect(rng=rng, config=config, **data)
+    diagnostics = res.pop('_diagnostics')
 
     # we remove the DETECTED bit
     assert np.all(res['noshear']['bmask'] & detected == 0)
@@ -253,6 +264,36 @@ def test_lsst_metadetect_shear_bands():
             assert np.any(res[shear][f"{front}_flags"] == 0)
             assert np.all(res[shear]["mfrac"] == 0)
             assert res[shear][flux_name].shape == (25, nband)
+
+    perband = diagnostics['psf_stats_perband']
+    assert perband.size == len(bands)
+
+    wgts = diagnostics['weight_perband']
+    assert len(wgts) == len(bands)
+    assert all(band in bands for band in wgts)
+    for iband, band in enumerate(bands):
+        assert perband['band'][iband] == band
+        if band in shear_bands:
+            assert wgts[band] > 0
+        else:
+            assert wgts[band] == 0
+
+    wgts_list = list(wgts.values())
+    psf_stats = diagnostics['psf_stats_average']
+    T = np.average(perband['T'], weights=wgts_list)
+    e1 = np.average(perband['e1'], weights=wgts_list)
+    e2 = np.average(perband['e2'], weights=wgts_list)
+    g1, g2 = ngmix.shape.e1e2_to_g1g2(e1, e2)
+
+    assert psf_stats['T'] == T
+    assert psf_stats['e1'] == e1
+    assert psf_stats['e2'] == e2
+    assert psf_stats['g1'] == g1
+    assert psf_stats['g2'] == g2
+
+    np.testing.assert_allclose(res['noshear']['psfrec_g'][:, 0], g1)
+    np.testing.assert_allclose(res['noshear']['psfrec_g'][:, 1], g2)
+    np.testing.assert_allclose(res['noshear']['psfrec_T'], T)
 
     for shear in metacal_types:
         assert np.all(res[shear]["shear_bands"] == np.array([["13"]]))


### PR DESCRIPTION
This PR fixes the bug with non-shear bands affecting the average PSF stats in the simplest possible way, implementing https://github.com/esheldon/metadetect/pull/255#issuecomment-4409177064

- The first commit is the actual change needed to fix the bug, which is achieved by setting the weight of non-shear bands to zero. The rest of the changes are unit tests and changing the code organization to support those unit tests better.
- The second commit does some refactoring to straighten out the relevant part of the code and provides info for unit tests. In particular, it breaks up the fit_original_psf_mbexp to just return the per-band PSF stats, and have a separate function to compute the weighted average across bands.
- The third commit adds tests from Erin, modified to work with the changes in the previous commit.
- Finally, the fourth commit adds a leading underscore to denote that these are private functions, and marking the point where the input arguments and output format have changed.