### PR TITLE
azgauss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.13.1
+
+### changed
+
+    - use new azgauss reconvolution kernel in lsst.
+    - reworked lsst deblender config
+
 ## 0.13.0 - 2025-12-02, 2026-05-08
 
 ### changed

--- a/metadetect/lsst/metacal_exposures.py
+++ b/metadetect/lsst/metacal_exposures.py
@@ -2,7 +2,7 @@
 Code to do metacal with lsst exposures
 """
 import numpy as np
-from ngmix.metacal.metacal import _get_gauss_target_psf, _get_ellip_dilation
+from ngmix.metacal.azgauss_target_psf import get_azgauss_target_psf
 import galsim
 import lsst.afw.image as afw_image
 from .util import (
@@ -210,7 +210,7 @@ def get_metacal_exps(exp, psf_stats=None, types=None, rot=False):
             flux=psf_flux,
         )
     else:
-        gauss_psf = _get_gauss_target_psf(psf_int, flux=psf_flux)
+        gauss_psf = get_azgauss_target_psf(psf_int, flux=psf_flux)
 
     dilation = 1.0 + 2.0 * STEP
     psf_dilated = gauss_psf.dilate(dilation)
@@ -333,3 +333,31 @@ def _get_fitgauss_target_psf(e1, e2, T, flux):
         sigma=sigma,
         flux=flux,
     )
+
+
+def _get_ellip_dilation(e1, e2, T):
+    """
+    when making a new image after shearing, we need to dilate the PSF to hide
+    modes that get exposed
+    """
+    from ngmix import moments
+
+    irr, irc, icc = moments.e2mom(e1, e2, T)
+
+    mat = np.zeros((2, 2))
+    mat[0, 0] = irr
+    mat[0, 1] = irc
+    mat[1, 0] = irc
+    mat[1, 1] = icc
+
+    eigs = np.linalg.eigvals(mat)
+
+    dilation = eigs.max() / (T / 2.0)
+    dilation = np.sqrt(dilation)
+
+    dilation = 1.0 + 2 * (dilation - 1.0)
+
+    if dilation > 1.1:
+        dilation = 1.1
+
+    return dilation

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -94,8 +94,10 @@ def run_metadetect(
     """
 
     config_override = deepcopy(DEFAULT_MDET_CONFIG)
+
     if config:
-        config_override.update(config)
+        # copy so the pop below won't pop a reference in the input config
+        config_override.update(deepcopy(config))
 
     config = MetadetectConfig()
     config.setDefaults()
@@ -105,11 +107,17 @@ def run_metadetect(
         config_override['detect_and_deblend']['deblend'] = deepcopy(
             DEFAULT_DEBLEND_SCARLET_CONFIG
         )
-        assert config_override['detect_and_deblend']['deblend'].pop('name') == 'scarlet'
+        assert (
+            config_override['detect_and_deblend']['deblend'].pop('name')
+            == 'scarlet'
+        )
         config.detect_and_deblend.deblend.retarget(ScarletDeblendTask)
     elif deblender == 'sdss':
         # SDSS deblender is the default, so no need to override
-        assert config_override['detect_and_deblend']['deblend'].pop('name') == 'sdss'
+        assert (
+            config_override['detect_and_deblend']['deblend'].pop('name')
+            == 'sdss'
+        )
     else:
         raise ValueError(f"Unknown deblender: {deblender}")
 
@@ -151,7 +159,10 @@ class MetacalConfig(Config):
         default="azgauss",
         allowed={
             "fitgauss": "Use a gaussian fit to determine reconvolution kernel",
-            "azgauss": "Use noise robust, k-space power to determine reconvolution kernel",
+            "azgauss": (
+                "Use noise robust, k-space power to determine reconvolution "
+                "kernel"
+            ),
         },
     )
 
@@ -267,7 +278,9 @@ class MetadetectTask(Task):
         for shear_str, mcal_mbexp in mdict.items():
             if rng is not None:
                 dbtask.rng = rng
-            sources, detexp, model_data = dbtask.run(mbexp=mcal_mbexp, show=show)
+            sources, detexp, model_data = dbtask.run(
+                mbexp=mcal_mbexp, show=show,
+            )
 
             res = measure.measure(
                 mbexp=mcal_mbexp,

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -148,10 +148,10 @@ class MetacalConfig(Config):
 
     reconv_type = ChoiceField[str](
         doc="Type of reconvolution kernel to use",
-        default="fitgauss",
+        default="azgauss",
         allowed={
             "fitgauss": "Use a gaussian fit to determine reconvolution kernel",
-            "gauss": "Use k-space power to determine reconvolution kernel",
+            "azgauss": "Use noise robust, k-space power to determine reconvolution kernel",
         },
     )
 

--- a/metadetect/lsst/tests/test_lsst_metacal_exposures.py
+++ b/metadetect/lsst/tests/test_lsst_metacal_exposures.py
@@ -80,7 +80,7 @@ def test_metacal_exps(ntrial=10, show=False):
 
         types = ('noshear', '1p', '1m', '2p', '2m')
         mdict_obs = get_all_metacal(
-            obs, use_noise_image=True, types=types,
+            obs, use_noise_image=True, types=types, psf='azgauss',
         )
         mdict_exp, noise_mdict = get_metacal_exps_fixnoise(
             exp, nexp, types=types,
@@ -158,7 +158,7 @@ def test_metacal_mbexp(ntrial=10, show=False):
 
         types = ('noshear', '1p', '1m', '2p', '2m')
         mdict_obs = get_all_metacal(
-            mbobs, use_noise_image=True, types=types,
+            mbobs, use_noise_image=True, types=types, psf='azgauss',
         )
         mdict_mbexp, noise_mdict = get_metacal_mbexps_fixnoise(
             mbexp, noise_mbexp, types=types,

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -157,7 +157,7 @@ def test_lsst_metadetect_smoke(subtract_sky, metacal_types_option):
             assert len(res[shear][flux_name][0]) == len(bands)
 
 
-@pytest.mark.parametrize("metacal_reconv_option", [None, "fitgauss", "gauss"])
+@pytest.mark.parametrize("metacal_reconv_option", [None, "fitgauss", "azgauss"])
 def test_lsst_metadetect_reconv(metacal_reconv_option):
     rng = np.random.RandomState(seed=116)
 
@@ -179,38 +179,6 @@ def test_lsst_metadetect_reconv(metacal_reconv_option):
         assert test_config['metacal']['reconv_type'] == 'fitgauss'
 
     res = run_metadetect(rng=rng, config=config, **data)  # noqa
-
-
-@pytest.mark.xfail
-def test_lsst_metadetect_reconv_size():
-    """
-    This currently fails because the PSF images have no noise.  fitgauss
-    will outperform gauss for noisy PSFs
-    """
-    rng = np.random.RandomState(seed=232)
-
-    bands = ['r', 'i']
-    sim_data = make_lsst_sim(5520, bands=bands, psf_type='ps')
-    data = do_coadding(rng=rng, sim_data=sim_data, nowarp=True)
-
-    config = {}
-    config['metacal'] = {}
-    config['metacal']['reconv_type'] = 'fitgauss'
-    res_fitgauss = run_metadetect(rng=rng, config=config, **data)  # noqa
-
-    config['metacal']['reconv_type'] = 'gauss'
-    res_gauss = run_metadetect(rng=rng, config=config, **data)  # noqa
-
-    mT_fitgauss = res_fitgauss['noshear']['gauss_psf_T'].mean()
-    mT_gauss = res_gauss['noshear']['gauss_psf_T'].mean()
-
-    fwhm_fitgauss = ngmix.moments.T_to_fwhm(mT_fitgauss)
-    fwhm_gauss = ngmix.moments.T_to_fwhm(mT_gauss)
-
-    assert fwhm_fitgauss < fwhm_gauss, (
-        'expected fitgauss fwhm < gauss fwhm, '
-        f'got {fwhm_fitgauss} > {fwhm_gauss}'
-    )
 
 
 def test_lsst_metadetect_shear_bands_missing():


### PR DESCRIPTION
Use new azgauss method for reconvolution kernel in lsst sub package

This method is superior to fitgauss and gauss.

fitgauss is still available for a while in transition, but azgauss should be used going forward